### PR TITLE
Debugging configuration for x64 and WSL

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,9 +12,15 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "/W4 /EHs /GR",
+
         "CMAKE_CXX_COMPILER": "cl",
-        "CMAKE_C_COMPILER": "cl"
+        "CMAKE_C_COMPILER": "cl",
+        "CMAKE_CXX_FLAGS": "/W4 /EHs /GR",
+
+        "CMAKE_CXX_FLAGS_DEBUG": "/Od /Zi",
+        "CMAKE_CXX_FLAGS_RELEASE": "/O2 /DNDEBUG",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "/O2 /Zo /DNDEBUG"
+
       }
     },
     {
@@ -23,9 +29,14 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
-        "CMAKE_CXX_FLAGS": "-fexceptions -frtti -Wall",
+
         "CMAKE_CXX_COMPILER": "/usr/bin/g++",
-        "CMAKE_C_COMPILER": "/usr/bin/gcc"
+        "CMAKE_C_COMPILER": "/usr/bin/gcc",
+        "CMAKE_CXX_FLAGS": "-fexceptions -frtti -Wall",
+
+        "CMAKE_CXX_FLAGS_DEBUG": "-O0 -g",
+        "CMAKE_CXX_FLAGS_RELEASE": "-O3 -DNDEBUG",
+        "CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-02 -g -DNDEBUG"
       }
     },
     {

--- a/engine/source/main.cpp
+++ b/engine/source/main.cpp
@@ -3,6 +3,7 @@
 #include "sdl_app.hpp"
 
 #include <memory>
+#include <filesystem>
 
 std::shared_ptr<Application> g_app;
 std::unique_ptr<Engine> g_engine;

--- a/scripts/launch.vs.json
+++ b/scripts/launch.vs.json
@@ -3,11 +3,41 @@
   "defaults": {},
   "configurations": [
     {
-      "type": "default",
+      "type": "cppvsdbg",
+      "name": "Launch (x64)",
       "project": "CMakeLists.txt",
       "projectTarget": "Engine.exe",
-      "name": "Run Project",
       "currentDir": ""
+    },
+
+    {
+      "type": "cppdbg",
+      "name": "Launch (WSL)",
+      "project": "CMakeLists.txt",
+      "projectTarget": "Engine",
+      "program": "${cmake.binaryDir}/Engine",
+      "currentDir": "/home/user/.vs/Y2024-25-PR-BB",
+      "cwd": "/home/user/.vs/Y2024-25-PR-BB",
+
+      "MIMode": "gdb",
+      "miDebuggerPath": "/usr/bin/gdb",
+      "externalConsole": false,
+
+      "pipeTransport": {
+        "pipeProgram": "wsl",
+        "pipeArgs": [],
+        "pipeCwd": "",
+        "debuggerPath": "/usr/bin/gdb",
+        "quoteArgs": false
+      },
+
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
[Fixed] some compiler flags missing on WSL debug builds (namely for debug info)
[Changed] launch.vs.json copy file for configuring debugger launch