### PR TITLE
Add TracyAlloc and TracyFree for memory profiling on tracy

### DIFF
--- a/engine/include/pch.hpp
+++ b/engine/include/pch.hpp
@@ -36,6 +36,18 @@
 #include <implot.h>
 #include "tracy/Tracy.hpp"
 
+inline void* operator new(std::size_t count)
+{
+    auto ptr = malloc (count);
+    TracyAlloc (ptr, count);
+    return ptr ;
+}
+inline void operator delete(void* ptr) noexcept
+{
+    TracyFree (ptr);
+    free (ptr);
+}
+
 constexpr uint32_t MAX_FRAMES_IN_FLIGHT{ 3 };
 constexpr uint32_t DEFERRED_ATTACHMENT_COUNT{ 4 };
 


### PR DESCRIPTION
redefining new and delete to allow Tracy to profile memory
![image](https://github.com/user-attachments/assets/f2d7c70a-3cb2-45b2-bfaa-7a0074c73364)
