### PR TITLE
Features/mesh shapes

### DIFF
--- a/assets/models/collision_test.glb
+++ b/assets/models/collision_test.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b85b0761b04d6508bd6289723c1344dc71b6aaf5dec84325003408e88056945f
+size 2540

--- a/assets/models/monkey.bin
+++ b/assets/models/monkey.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5510ba44b7ebdf1e462e9872a2d2ccd808c0e76f8107dc5c0c4b93853d45163b
+size 699248

--- a/assets/models/monkey.gltf
+++ b/assets/models/monkey.gltf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a2f75271d152953ae2a5f2270e5cf2faeeb2310a2e71a14159adc3c884860aa
-size 944103
+oid sha256:19d5f58f5a587cd0c8c2e509fdde7146927eb25405dc6e4178371037d4f8f731
+size 13586

--- a/engine/ecs/private/components/transform_helpers.cpp
+++ b/engine/ecs/private/components/transform_helpers.cpp
@@ -228,6 +228,14 @@ void TransformHelpers::UnsubscribeToEvents(entt::registry& reg)
     reg.on_construct<TransformComponent>().disconnect<&OnConstructTransform>();
     reg.on_destroy<TransformComponent>().disconnect<&OnDestroyTransform>();
 }
+void TransformHelpers::ResetAllUpdateTags(entt::registry& reg)
+{
+    auto view = reg.view<ToBeUpdated>();
+    for (auto entity : view)
+    {
+        reg.remove<ToBeUpdated>(entity);
+    }
+}
 void TransformHelpers::UpdateWorldMatrix(entt::registry& reg, entt::entity entity)
 {
     assert(reg.valid(entity));
@@ -261,4 +269,5 @@ void TransformHelpers::UpdateWorldMatrix(entt::registry& reg, entt::entity entit
             current = reg.get<RelationshipComponent>(current).next;
         }
     }
+    reg.emplace_or_replace<ToBeUpdated>(entity);
 }

--- a/engine/ecs/public/components/transform_component.hpp
+++ b/engine/ecs/public/components/transform_component.hpp
@@ -20,7 +20,10 @@ private:
     friend class TransformHelpers;
     friend class Editor;
 };
-
+struct ToBeUpdated
+{
+    int padding {};
+};
 namespace EnttEditor
 {
 template <>

--- a/engine/ecs/public/components/transform_helpers.hpp
+++ b/engine/ecs/public/components/transform_helpers.hpp
@@ -42,6 +42,8 @@ public:
     static void SubscribeToEvents(entt::registry& reg);
     static void UnsubscribeToEvents(entt::registry& reg);
 
+    static void ResetAllUpdateTags(entt::registry& reg);
+
 private:
     friend class Editor;
     friend struct TransformComponent;

--- a/engine/include/scene_loader.hpp
+++ b/engine/include/scene_loader.hpp
@@ -14,5 +14,5 @@ struct Animation;
 
 namespace SceneLoading
 {
-entt::entity LoadModelIntoECSAsHierarchy(ECSModule& ecs, const GPUModel& gpuModel, const Hierarchy& hierarchy, std::optional<Animation> animation = std::nullopt);
+entt::entity LoadModelIntoECSAsHierarchy(ECSModule& ecs, const GPUModel& gpuModel, const CPUModel& cpuModel, const Hierarchy& hierarchy, std::optional<Animation> animation = std::nullopt);
 };

--- a/engine/physics/public/components/rigidbody_component.hpp
+++ b/engine/physics/public/components/rigidbody_component.hpp
@@ -56,6 +56,38 @@ struct RigidbodyComponent
         bodyInterface.SetUserData(bodyID, static_cast<uintptr_t>(ownerEntity));
     }
 
+    // for mesh collisions
+    RigidbodyComponent(JPH::BodyInterface& bodyInterface, entt::entity ownerEntity, glm::vec3 position, JPH::VertexList& vertices, JPH::IndexedTriangleList& triangles)
+        : shapeType(eBOX)
+        , bodyType(eSTATIC)
+    {
+        JPH::BodyCreationSettings bodySettings;
+
+        JPH::MeshShapeSettings meshSettings;
+        JPH::ShapeSettings::ShapeResult shapeResult;
+
+        if (bodyType == eSTATIC)
+        {
+            bodySettings = JPH::BodyCreationSettings(
+                new JPH::MeshShapeSettings(vertices, triangles),
+                JPH::Vec3Arg(position.x, position.y, position.z),
+                JPH::QuatArg::sIdentity(),
+                JPH::EMotionType::Static,
+                PhysicsLayers::NON_MOVING);
+        }
+
+        if (shapeResult.HasError())
+        {
+            bblog::error(shapeResult.GetError().c_str());
+        }
+
+        bodySettings.mAllowDynamicOrKinematic = false;
+        bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
+
+        // set the owner entity so we can query it later from physics objects if needed
+        bodyInterface.SetUserData(bodyID, static_cast<uintptr_t>(ownerEntity));
+    }
+
     // for AABB collisions
     RigidbodyComponent(JPH::BodyInterface& bodyInterface, entt::entity ownerEntity, glm::vec3 position, Vec3Range boundingBox, BodyType type = eSTATIC)
         : shapeType(eBOX)

--- a/engine/physics/public/components/rigidbody_component.hpp
+++ b/engine/physics/public/components/rigidbody_component.hpp
@@ -81,7 +81,11 @@ struct RigidbodyComponent
             bblog::error(shapeResult.GetError().c_str());
         }
 
-        bodySettings.mAllowDynamicOrKinematic = false;
+        // lets save thes hape reference
+        shape = bodySettings.GetShape();
+
+        bodySettings.mAllowDynamicOrKinematic
+            = false;
         bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
         // set the owner entity so we can query it later from physics objects if needed
@@ -119,7 +123,8 @@ struct RigidbodyComponent
             bblog::error(shapeResult.GetError().c_str());
         }
 
-        bodySettings.mAllowDynamicOrKinematic = false;
+        shape = bodySettings.GetShape();
+        bodySettings.mAllowDynamicOrKinematic = true;
         bodyID = bodyInterface.CreateAndAddBody(bodySettings, JPH::EActivation::Activate);
 
         // set the owner entity so we can query it later from physics objects if needed
@@ -173,5 +178,6 @@ struct RigidbodyComponent
 
     JPH::BodyID bodyID;
     PhysicsShapes shapeType;
+    JPH::ShapeRefC shape;
     BodyType bodyType;
 };

--- a/engine/physics/public/physics_module.hpp
+++ b/engine/physics/public/physics_module.hpp
@@ -11,10 +11,9 @@
 #include <Jolt/Physics/Collision/RayCast.h>
 
 #include "module_interface.hpp"
+#include <Jolt/Physics/Collision/Shape/ConvexHullShape.h>
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/Collision/Shape/Shape.h>
-
-
 
 JPH_SUPPRESS_WARNING_PUSH
 

--- a/engine/physics/public/physics_module.hpp
+++ b/engine/physics/public/physics_module.hpp
@@ -11,6 +11,10 @@
 #include <Jolt/Physics/Collision/RayCast.h>
 
 #include "module_interface.hpp"
+#include <Jolt/Physics/Collision/Shape/MeshShape.h>
+#include <Jolt/Physics/Collision/Shape/Shape.h>
+
+
 
 JPH_SUPPRESS_WARNING_PUSH
 

--- a/engine/physics/public/physics_module.hpp
+++ b/engine/physics/public/physics_module.hpp
@@ -58,6 +58,8 @@ enum PhysicsShapes
     eSPHERE,
     eBOX,
     eCUSTOM,
+    eCONVEXHULL,
+    eMESH,
 };
 
 enum BodyType

--- a/engine/physics/public/systems/physics_system.hpp
+++ b/engine/physics/public/systems/physics_system.hpp
@@ -15,6 +15,8 @@ public:
 
     void InitializePhysicsColliders();
 
+    void CreateMeshCollision(const std::string& path);
+
     void CleanUp();
     void Update(ECSModule& ecs, float deltaTime) override;
     void Render(const ECSModule& ecs) const override;

--- a/engine/physics/public/systems/physics_system.hpp
+++ b/engine/physics/public/systems/physics_system.hpp
@@ -18,7 +18,10 @@ public:
     void InitializePhysicsColliders();
 
     void CreateMeshCollision(const std::string& path);
+    void CreateMeshCollision(const CPUModel& model);
+
     void CreateConvexHullCollision(const std::string& path);
+    void CreateConvexHullCollision(const CPUModel& model);
 
     void CleanUp();
     void Update(ECSModule& ecs, float deltaTime) override;
@@ -27,7 +30,7 @@ public:
     void InspectRigidBody(RigidbodyComponent& rb);
 
 private:
-    entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, Hierarchy& hierarchy, entt::entity parent, PhysicsShapes shape);
+    entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, const Hierarchy& hierarchy, entt::entity parent, PhysicsShapes shape);
 
     Engine& engine;
     ECSModule& _ecs;

--- a/engine/physics/public/systems/physics_system.hpp
+++ b/engine/physics/public/systems/physics_system.hpp
@@ -3,9 +3,10 @@
 #include "ecs_module.hpp"
 #include "entt/entity/entity.hpp"
 
+struct Hierarchy;
 class PhysicsModule;
 struct RigidbodyComponent;
-
+class CPUModel;
 class PhysicsSystem : public SystemInterface
 {
 public:
@@ -16,6 +17,7 @@ public:
     void InitializePhysicsColliders();
 
     void CreateMeshCollision(const std::string& path);
+    void CreateConvexHullCollision(const std::string& path);
 
     void CleanUp();
     void Update(ECSModule& ecs, float deltaTime) override;
@@ -24,6 +26,8 @@ public:
     void InspectRigidBody(RigidbodyComponent& rb);
 
 private:
+    entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, Hierarchy& hierarchy, entt::entity parent);
+
     Engine& engine;
     ECSModule& _ecs;
     PhysicsModule& _physicsModule;

--- a/engine/physics/public/systems/physics_system.hpp
+++ b/engine/physics/public/systems/physics_system.hpp
@@ -7,6 +7,7 @@ struct Hierarchy;
 class PhysicsModule;
 struct RigidbodyComponent;
 class CPUModel;
+enum PhysicsShapes;
 class PhysicsSystem : public SystemInterface
 {
 public:
@@ -26,7 +27,7 @@ public:
     void InspectRigidBody(RigidbodyComponent& rb);
 
 private:
-    entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, Hierarchy& hierarchy, entt::entity parent);
+    entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, Hierarchy& hierarchy, entt::entity parent, PhysicsShapes shape);
 
     Engine& engine;
     ECSModule& _ecs;

--- a/engine/physics/public/systems/physics_system.hpp
+++ b/engine/physics/public/systems/physics_system.hpp
@@ -3,10 +3,15 @@
 #include "ecs_module.hpp"
 #include "entt/entity/entity.hpp"
 
+struct Vertex;
 struct Hierarchy;
 class PhysicsModule;
 struct RigidbodyComponent;
-class CPUModel;
+struct CPUModel;
+
+template <typename T>
+struct CPUMesh;
+
 enum PhysicsShapes;
 class PhysicsSystem : public SystemInterface
 {
@@ -18,10 +23,9 @@ public:
     void InitializePhysicsColliders();
 
     void CreateMeshCollision(const std::string& path);
-    void CreateMeshCollision(const CPUModel& model);
+    RigidbodyComponent CreateMeshColliderBody(const CPUMesh<Vertex>& mesh, PhysicsShapes shapeType, entt::entity entityToAttachTo = entt::null);
 
     void CreateConvexHullCollision(const std::string& path);
-    void CreateConvexHullCollision(const CPUModel& model);
 
     void CleanUp();
     void Update(ECSModule& ecs, float deltaTime) override;
@@ -30,7 +34,11 @@ public:
     void InspectRigidBody(RigidbodyComponent& rb);
 
 private:
+    // for loading mesh data or convex data into the scene with no rendering mesh relation
     entt::entity LoadNodeRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, const Hierarchy& hierarchy, entt::entity parent, PhysicsShapes shape);
+
+    // for loading mesh data or convex data into the scene. returns a vector of rigidbodies
+    std::vector<RigidbodyComponent> LoadBodiesRecursive(const CPUModel& models, ECSModule& ecs, uint32_t currentNodeIndex, const Hierarchy& hierarchy, entt::entity parent, PhysicsShapes shape);
 
     Engine& engine;
     ECSModule& _ecs;

--- a/engine/source/engine.cpp
+++ b/engine/source/engine.cpp
@@ -47,13 +47,13 @@ ModuleTickOrder OldEngine::Init(Engine& engine)
     // modules
 
     std::vector<std::string> modelPaths = {
-        "assets/models/Cathedral.glb"
+        //"assets/models/Cathedral.glb"
         //"assets/models/BrainStem.glb",
         //"assets/models/Adventure.glb",
         //"assets/models/DamagedHelmet.glb",
         //"assets/models/CathedralGLB_GLTF.glb",
-        // "assets/models/Terrain/scene.gltf",
-        //"assets/models/ABeautifulGame/ABeautifulGame.gltf",
+        //"assets/models/Terrain/scene.gltf",
+        "assets/models/ABeautifulGame/ABeautifulGame.gltf",
         //"assets/models/MetalRoughSpheres.glb"
     };
 

--- a/engine/source/engine.cpp
+++ b/engine/source/engine.cpp
@@ -53,8 +53,9 @@ ModuleTickOrder OldEngine::Init(Engine& engine)
         //"assets/models/DamagedHelmet.glb",
         //"assets/models/CathedralGLB_GLTF.glb",
         //"assets/models/Terrain/scene.gltf",
-        "assets/models/ABeautifulGame/ABeautifulGame.gltf",
-        //"assets/models/MetalRoughSpheres.glb"
+        //"assets/models/ABeautifulGame/ABeautifulGame.gltf",
+        //"assets/models/MetalRoughSpheres.glb",
+        "assets/models/monkey.gltf"
     };
 
     particleModule.LoadEmitterPresets();

--- a/engine/source/engine.cpp
+++ b/engine/source/engine.cpp
@@ -67,7 +67,7 @@ ModuleTickOrder OldEngine::Init(Engine& engine)
 
     _ecs = &engine.GetModule<ECSModule>();
 
-    SceneLoading::LoadModelIntoECSAsHierarchy(*_ecs, *modelResourceManager.Access(models[0].second), models[0].first.hierarchy, models[0].first.animation);
+    SceneLoading::LoadModelIntoECSAsHierarchy(*_ecs, *modelResourceManager.Access(models[0].second), models[0].first, models[0].first.hierarchy, models[0].first.animation);
 
     // TransformHelpers::SetLocalScale(_ecs->GetRegistry(), entities[1], glm::vec3 { 4.0f });
     // TransformHelpers::SetLocalPosition(_ecs->GetRegistry(), entities[1], glm::vec3 { 106.0f, 14.0f, 145.0f });

--- a/engine/source/scene_loader.cpp
+++ b/engine/source/scene_loader.cpp
@@ -26,6 +26,7 @@ entt::entity LoadNodeRecursive(ECSModule& ecs,
     const Hierarchy& hierarchy,
     entt::entity parent,
     const GPUModel& model,
+    const CPUModel& cpuModel,
     std::shared_ptr<Animation> animation,
     std::unordered_map<uint32_t, entt::entity>& entityLUT, // Used for looking up from hierarchy node index to entt entity.
     entt::entity skeletonRoot = entt::null)
@@ -52,6 +53,13 @@ entt::entity LoadNodeRecursive(ECSModule& ecs,
         {
         case MeshType::eSTATIC:
             ecs.GetRegistry().emplace<StaticMeshComponent>(entity).mesh = model.staticMeshes.at(currentNode.meshIndex.value().second);
+
+            // check if it should have collider
+
+            ecs.GetRegistry().emplace<RigidbodyComponent>(entity, ecs.GetSystem<PhysicsSystem>()->CreateMeshColliderBody(cpuModel.meshes.at(currentNode.meshIndex.value().second), PhysicsShapes::eCONVEXHULL, entity));
+
+            // add collider recursively
+
             break;
         case MeshType::eSKINNED:
             ecs.GetRegistry().emplace<SkinnedMeshComponent>(entity).mesh = model.skinnedMeshes.at(currentNode.meshIndex.value().second);
@@ -84,13 +92,13 @@ entt::entity LoadNodeRecursive(ECSModule& ecs,
 
     for (const auto& nodeIndex : currentNode.children)
     {
-        LoadNodeRecursive(ecs, nodeIndex, hierarchy, entity, model, animation, entityLUT, skeletonRoot);
+        LoadNodeRecursive(ecs, nodeIndex, hierarchy, entity, model, cpuModel, animation, entityLUT, skeletonRoot);
     }
 
     return entity;
 }
 
-entt::entity SceneLoading::LoadModelIntoECSAsHierarchy(ECSModule& ecs, const GPUModel& gpuModel, const Hierarchy& hierarchy, std::optional<Animation> animation)
+entt::entity SceneLoading::LoadModelIntoECSAsHierarchy(ECSModule& ecs, const GPUModel& gpuModel, const CPUModel& cpuModel, const Hierarchy& hierarchy, std::optional<Animation> animation)
 {
     std::shared_ptr<Animation> animationControl { nullptr };
     if (animation.has_value())
@@ -100,7 +108,7 @@ entt::entity SceneLoading::LoadModelIntoECSAsHierarchy(ECSModule& ecs, const GPU
 
     std::unordered_map<uint32_t, entt::entity> entityLUT;
 
-    entt::entity rootEntity = LoadNodeRecursive(ecs, hierarchy.root, hierarchy, entt::null, gpuModel, animationControl, entityLUT);
+    entt::entity rootEntity = LoadNodeRecursive(ecs, hierarchy.root, hierarchy, entt::null, gpuModel, cpuModel, animationControl, entityLUT);
 
     for (size_t i = 0; i < hierarchy.nodes.size(); ++i)
     {


### PR DESCRIPTION
### Description

Added support for complex hierarchies with jolt. 
Added mesh and convex hull colliders for entities with static mesh component
Added function to load only collision data as gltf using either mesh or convex hull shapes

![image](https://github.com/user-attachments/assets/cc796fb9-6fa9-41ff-8bee-48418d78d547)
![image](https://github.com/user-attachments/assets/c0fafd12-2e4d-4aeb-84a4-664da6891ed7)

### Issues

https://bubonic-brotherhood.codecks.io/card/1g1-mesh-shapes-for-colliders
https://bubonic-brotherhood.codecks.io/decks/7-engine/card/1g5-sync-physics-and-rendering-with-hierarchy

### Test criteria

- [ ] Play around in the editor to see how things work
- [ ] There should still be some minor issues that can be fix with early returns in certain scenarios.
- [ ] There is this big issue where dynamic bodies that have non uniform scaling will reset the mesh scale to 1.0 during simulation because jolt world transform does not hold scale. If you have any ideas how to fix this please help.