### PR TITLE
Fix normal transforms

### DIFF
--- a/engine/renderer/private/gpu_scene.cpp
+++ b/engine/renderer/private/gpu_scene.cpp
@@ -25,6 +25,7 @@
 
 #include <glm/gtc/matrix_transform.hpp>
 #include <unordered_map>
+#include <tracy/Tracy.hpp>
 
 GPUScene::GPUScene(const GPUSceneCreation& creation)
     : irradianceMap(creation.irradianceMap)
@@ -58,6 +59,7 @@ GPUScene::~GPUScene()
 
 void GPUScene::Update(uint32_t frameIndex)
 {
+    ZoneScoped;
     UpdateSceneData(frameIndex);
     UpdatePointLightArray(frameIndex);
     UpdateCameraData(frameIndex);

--- a/engine/renderer/private/renderer.cpp
+++ b/engine/renderer/private/renderer.cpp
@@ -93,7 +93,7 @@ Renderer::Renderer(ApplicationModule& application, Viewport& viewport, const std
 
     // temporary location
     auto font = LoadFromFile("assets/fonts/JosyWine-G33rg.ttf", 48, _context);
-    viewport.AddElement(std::make_unique<MainMenuCanvas>(_viewport.GetExtend(), _context, font));
+    //viewport.AddElement(std::make_unique<MainMenuCanvas>(_viewport.GetExtend(), _context, font));
 
     _geometryPipeline = std::make_unique<GeometryPipeline>(_context, *_gBuffers, *_gpuScene);
     _skydomePipeline = std::make_unique<SkydomePipeline>(_context, uvSphere, _hdrTarget, _brightnessTarget, _environmentMap, *_gBuffers, *_bloomSettings);

--- a/engine/renderer/private/renderer.cpp
+++ b/engine/renderer/private/renderer.cpp
@@ -91,10 +91,6 @@ Renderer::Renderer(ApplicationModule& application, Viewport& viewport, const std
 
     _gpuScene = std::make_shared<GPUScene>(gpuSceneCreation);
 
-    // temporary location
-    auto font = LoadFromFile("assets/fonts/JosyWine-G33rg.ttf", 48, _context);
-    //viewport.AddElement(std::make_unique<MainMenuCanvas>(_viewport.GetExtend(), _context, font));
-
     _geometryPipeline = std::make_unique<GeometryPipeline>(_context, *_gBuffers, *_gpuScene);
     _skydomePipeline = std::make_unique<SkydomePipeline>(_context, uvSphere, _hdrTarget, _brightnessTarget, _environmentMap, *_gBuffers, *_bloomSettings);
     _tonemappingPipeline = std::make_unique<TonemappingPipeline>(_context, _hdrTarget, _bloomTarget, _tonemappingTarget, *_swapChain, *_bloomSettings);

--- a/engine/source/engine.cpp
+++ b/engine/source/engine.cpp
@@ -55,7 +55,7 @@ ModuleTickOrder OldEngine::Init(Engine& engine)
         //"assets/models/DamagedHelmet.glb",
         //"assets/models/CathedralGLB_GLTF.glb",
         // "assets/models/Terrain/scene.gltf",
-        "assets/models/ABeautifulGame/ABeautifulGame.gltf",
+        //"assets/models/ABeautifulGame/ABeautifulGame.gltf",
         //"assets/models/MetalRoughSpheres.glb"
     };
 
@@ -69,7 +69,6 @@ ModuleTickOrder OldEngine::Init(Engine& engine)
     _ecs = &engine.GetModule<ECSModule>();
 
     SceneLoading::LoadModelIntoECSAsHierarchy(*_ecs, *modelResourceManager.Access(models[0].second), models[0].first.hierarchy, models[0].first.animation);
-    SceneLoading::LoadModelIntoECSAsHierarchy(*_ecs, *modelResourceManager.Access(models[1].second), models[1].first.hierarchy, models[1].first.animation);
 
     // TransformHelpers::SetLocalScale(_ecs->GetRegistry(), entities[1], glm::vec3 { 4.0f });
     // TransformHelpers::SetLocalPosition(_ecs->GetRegistry(), entities[1], glm::vec3 { 106.0f, 14.0f, 145.0f });

--- a/shaders/geom.vert
+++ b/shaders/geom.vert
@@ -23,15 +23,26 @@ layout (location = 2) out vec2 texCoord;
 layout (location = 3) out flat int drawID;
 layout (location = 4) out mat3 TBN;
 
+mat3 Adjoint(in mat4 m)
+{
+    return mat3(
+            cross(m[1].xyz, m[2].xyz),
+            cross(m[2].xyz, m[0].xyz),
+            cross(m[0].xyz, m[1].xyz)
+    );
+}
+
 void main()
 {
     mat4 modelTransform = instances[gl_DrawID].model;
     drawID = gl_DrawID;
 
     position = (modelTransform * vec4(inPosition, 1.0)).xyz;
-    normal = normalize((modelTransform * vec4(inNormal, 0.0)).xyz);
-    vec3 tangent = normalize((modelTransform * vec4(inTangent.xyz, 0.0)).xyz);
-    vec3 bitangent = normalize((modelTransform * vec4(inTangent.w * cross(inNormal, inTangent.xyz), 0.0)).xyz);
+
+    mat3 normalTransform = Adjoint(modelTransform);
+    normal = normalize(normalTransform * inNormal);
+    vec3 tangent = normalize(normalTransform * inTangent.xyz);
+    vec3 bitangent = normalize(normalTransform * (inTangent.w * cross(inNormal, inTangent.xyz)));
     TBN = mat3(tangent, bitangent, normal);
     texCoord = inTexCoord;
 


### PR DESCRIPTION
### Description

Normals transforms properly fixed. Normally this is implemented through a normal matrix using a transpose inverse. But this uses an adjoint matrix approach https://www.shadertoy.com/view/3s33zj. 

![Screenshot_1](https://github.com/user-attachments/assets/841ba9f9-0b44-4dae-815a-3c1557aa78dd)
Before
![Screenshot_2](https://github.com/user-attachments/assets/9c855466-4963-4b1c-bb67-bed4f072490c)
After
![image](https://github.com/user-attachments/assets/bf70b93c-be1b-4901-a339-eee8bee8483b)
Split

### Test criteria

- [ ] Check whether scaling objects now uses proper lighting calculations.