### PR TITLE
Frame graph sorting fix

### DIFF
--- a/engine/renderer/private/frame_graph.cpp
+++ b/engine/renderer/private/frame_graph.cpp
@@ -463,7 +463,7 @@ void FrameGraph::CreateGeneralImageBarrier(const GPUImage& image, ResourceState 
         break;
     }
     default:
-        bblog::error("[Frame Graph] Unsupported depth image resource usage: {}", magic_enum::enum_name(state));
+        bblog::error("[Frame Graph] Unsupported general image resource usage: {}", magic_enum::enum_name(state));
         break;
     }
 }
@@ -579,7 +579,6 @@ void FrameGraph::SortGraph()
     for (int32_t i = reverseSortedNodes.size() - 1; i >= 0; --i)
     {
         _sortedNodes.push_back(reverseSortedNodes[i]);
-        bblog::info(_nodes[_sortedNodes.back()].name);
     }
 }
 

--- a/engine/renderer/public/frame_graph.hpp
+++ b/engine/renderer/public/frame_graph.hpp
@@ -188,6 +188,7 @@ private:
     void CreateImageBarrier(const FrameGraphResource& resource, ResourceState state, vk::ImageMemoryBarrier2& barrier) const;
     void CreateColorImageBarrier(const GPUImage& image, ResourceState state, vk::ImageMemoryBarrier2& barrier) const;
     void CreateDepthImageBarrier(const GPUImage& image, ResourceState state, vk::ImageMemoryBarrier2& barrier) const;
+    void CreateGeneralImageBarrier(const GPUImage& image, ResourceState state, vk::ImageMemoryBarrier2& barrier) const;
     void CreateBufferBarrier(const FrameGraphResource& resource, ResourceState state, vk::BufferMemoryBarrier2& barrier) const;
     void SortGraph();
     FrameGraphResourceHandle CreateOutputResource(const FrameGraphResourceCreation& creation, FrameGraphNodeHandle producer);


### PR DESCRIPTION
### Description

Previously the edge generation for frame graph nodes didn't account for reusable output resources, now it does, which fixes the order of execution of render passes. I also added a generic image barrier setup.

### Issues

_Provide a list of related issues that should be closed_

### Test criteria

_Let the reviewer know what you would like to have tested and what you want feedback on_