### PR TITLE
Fix workflow deprecated action

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ashutoshvarma/setup-ninja@master
 
       - name: Setup Vulkan SDK
-        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        uses: humbletim/setup-vulkan-sdk@main
         with:
           vulkan-query-version: latest
           vulkan-components: Vulkan-Headers, Vulkan-Loader


### PR DESCRIPTION
This pull request fixes the workflow that uses a deprecated cache action version.

No review needed, PR-Checks should be sufficient.
