### PR TITLE
Disable precomp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ option(WARNINGS_AS_ERRORS "Enable warnings as errors" OFF)
 option(COMPILE_TESTS "Compile with Unit Tests" ON)
 option(COMPILE_SHADERS "Compile all GLSL shaders as part of build step" ON)
 
-option(ENABLE_PCH "Compile with precompiled header" ON)
+option(ENABLE_PCH "Compile with precompiled header" OFF)
 option(ENABLE_UNITY "Compile using Unity Builds" ON)
 
 add_library(ProjectSettings INTERFACE)


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

This pull request disables use of precompiled headers in the configurations x64-Debug x64-Release, WSL-Debug WSL-Release.
![image](https://github.com/user-attachments/assets/39c58014-e754-4335-bcc1-82037b4bda2e)
Data represents full rebuild and full clear cache and reconfigure cmake.
The difference is smaller with incremental builds.

As a team we have decided to remove precomp relating to this data.
And the downside of having precomp enabled which causes errors in CI/CD of missing includes will be remedied.


### Issues

https://bubonic-brotherhood.codecks.io/card/1o8-disable-precomp-action-point

### Test criteria

none
