### PR TITLE
Feature/particle improved behavior

### DIFF
--- a/engine/inspector/private/menus/particle_editor.cpp
+++ b/engine/inspector/private/menus/particle_editor.cpp
@@ -97,8 +97,8 @@ void ParticleEditor::RenderEmitterPresetEditor()
         ImGui::DragFloat2("Size##EmitterPresetEditor", &selectedPreset.size.x, 0.1f, 0.0f, 100.0f);
         ImGui::DragFloat("Size velocity##EmitterPresetEditor", &selectedPreset.size.z, 0.1f, 0.0f, 100.0f);
         ImGui::DragFloat("Max life##EmitterPresetEditor", &selectedPreset.maxLife, 0.1f, 0.0f, 100.0f);
-        ImGui::DragFloat3("Randomness##EmitterPresetEditor", &selectedPreset.randomness.x, 0.1f, 0.0f, 100.0f);
-        ImGui::DragFloat3("Particle Randomness##EmitterPresetEditor", &selectedPreset.particleRandomness.x, 0.1f, 0.0f, 100.0f);
+        ImGui::DragFloat3("Spawn Randomness##EmitterPresetEditor", &selectedPreset.randomness.x, 0.1f, 0.0f, 100.0f);
+        ImGui::DragFloat3("Movement Randomness##EmitterPresetEditor", &selectedPreset.particleRandomness.x, 0.1f, 0.0f, 100.0f);
         ImGui::ColorPicker3("Color##EmitterPresetEditor", &selectedPreset.color.x);
         ImGui::DragFloat("Color Multiplier#EmitterPresetEditor", &selectedPreset.color.w, 0.1f, 0.0f, 100.0f);
 

--- a/engine/inspector/private/menus/particle_editor.cpp
+++ b/engine/inspector/private/menus/particle_editor.cpp
@@ -98,6 +98,7 @@ void ParticleEditor::RenderEmitterPresetEditor()
         ImGui::DragFloat("Size velocity##EmitterPresetEditor", &selectedPreset.size.z, 0.1f, 0.0f, 100.0f);
         ImGui::DragFloat("Max life##EmitterPresetEditor", &selectedPreset.maxLife, 0.1f, 0.0f, 100.0f);
         ImGui::DragFloat3("Randomness##EmitterPresetEditor", &selectedPreset.randomness.x, 0.1f, 0.0f, 100.0f);
+        ImGui::DragFloat3("Particle Randomness##EmitterPresetEditor", &selectedPreset.particleRandomness.x, 0.1f, 0.0f, 100.0f);
         ImGui::ColorPicker3("Color##EmitterPresetEditor", &selectedPreset.color.x);
         ImGui::DragFloat("Color Multiplier#EmitterPresetEditor", &selectedPreset.color.w, 0.1f, 0.0f, 100.0f);
 

--- a/engine/particles/private/emitter_component.cpp
+++ b/engine/particles/private/emitter_component.cpp
@@ -29,8 +29,8 @@ void ParticleEmitterComponent::Inspect()
     ImGui::DragFloat2("Size##Particle Emitter", &emitter.size.x, 0.1f, 0.0f, 100.0f);
     ImGui::DragFloat("Size velocity##Particle Emitter", &emitter.size.z, 0.1f, 0.0f, 100.0f);
     ImGui::DragFloat("Max life##Particle Emitter", &emitter.maxLife, 0.1f, 0.0f, 100.0f);
-    ImGui::DragFloat3("Randomness##EmitterPresetEditor", &emitter.randomness.x, 0.1f, 0.0f, 100.0f);
-    ImGui::DragFloat3("Particle Randomness##EmitterPresetEditor", &emitter.particleRandomness.x, 0.1f, 0.0f, 100.0f);
+    ImGui::DragFloat3("Spawn Randomness##EmitterPresetEditor", &emitter.randomness.x, 0.1f, 0.0f, 100.0f);
+    ImGui::DragFloat3("Movement Randomness##EmitterPresetEditor", &emitter.particleRandomness.x, 0.1f, 0.0f, 100.0f);
     ImGui::ColorPicker3("Color##Particle Emitter", &emitter.color.x);
     ImGui::DragFloat("Color Multiplier#Particle Emitter", &emitter.color.w, 0.1f, 0.0f, 100.0f);
 }

--- a/engine/particles/private/emitter_component.cpp
+++ b/engine/particles/private/emitter_component.cpp
@@ -30,6 +30,7 @@ void ParticleEmitterComponent::Inspect()
     ImGui::DragFloat("Size velocity##Particle Emitter", &emitter.size.z, 0.1f, 0.0f, 100.0f);
     ImGui::DragFloat("Max life##Particle Emitter", &emitter.maxLife, 0.1f, 0.0f, 100.0f);
     ImGui::DragFloat3("Randomness##EmitterPresetEditor", &emitter.randomness.x, 0.1f, 0.0f, 100.0f);
+    ImGui::DragFloat3("Particle Randomness##EmitterPresetEditor", &emitter.particleRandomness.x, 0.1f, 0.0f, 100.0f);
     ImGui::ColorPicker3("Color##Particle Emitter", &emitter.color.x);
     ImGui::DragFloat("Color Multiplier#Particle Emitter", &emitter.color.w, 0.1f, 0.0f, 100.0f);
 }

--- a/engine/particles/private/particle_module.cpp
+++ b/engine/particles/private/particle_module.cpp
@@ -149,7 +149,7 @@ void ParticleModule::LoadEmitterPresets()
 
         EmitterPreset preset;
         preset.emitDelay = 0.2f;
-        preset.mass = -0.250f;
+        preset.mass = -0.015f;
         preset.rotationVelocity = glm::vec2(0.0f, 0.0f);
         preset.maxLife = 3.0f;
         preset.count = 10;
@@ -168,7 +168,7 @@ void ParticleModule::LoadEmitterPresets()
 
         EmitterPreset preset;
         preset.emitDelay = 1.0f;
-        preset.mass = 0.150f;
+        preset.mass = 0.005f;
         preset.rotationVelocity = glm::vec2(0.0f, 0.0f);
         preset.maxLife = 8.0f;
         preset.count = 20;
@@ -189,7 +189,7 @@ void ParticleModule::LoadEmitterPresets()
         // hardcoded test emitter preset for now
         EmitterPreset preset;
         preset.emitDelay = 0.1f;
-        preset.mass = 5.0f;
+        preset.mass = 3.0f;
         preset.rotationVelocity = glm::vec2(0.0f, 0.0f);
         preset.maxLife = 1.0f;
         preset.count = 100;
@@ -246,6 +246,7 @@ void ParticleModule::SpawnEmitter(entt::entity entity, int32_t emitterPresetID, 
     emitter.rotationVelocity = preset.rotationVelocity;
     emitter.flags = preset.flags;
     emitter.randomness = preset.randomness;
+    emitter.particleRandomness = preset.particleRandomness;
     emitter.color = preset.color;
 
     // Set position and velocity according to which components the entity already has

--- a/engine/particles/private/particle_module.cpp
+++ b/engine/particles/private/particle_module.cpp
@@ -148,17 +148,18 @@ void ParticleModule::LoadEmitterPresets()
         auto image = GetEmitterImage("flame_03.png");
 
         EmitterPreset preset;
-        preset.emitDelay = 0.2f;
-        preset.mass = -0.015f;
+        preset.emitDelay = 0.1f;
+        preset.mass = -0.005f;
         preset.rotationVelocity = glm::vec2(0.0f, 0.0f);
-        preset.maxLife = 3.0f;
+        preset.maxLife = 2.0f;
         preset.count = 10;
-        preset.randomness = glm::vec3(0.120f, 1.0f, 0.120f);
-        preset.flags = static_cast<uint32_t>(ParticleRenderFlagBits::eNoShadow | ParticleRenderFlagBits::eSizeOverTime);
+        preset.randomness = glm::vec3(0.2f, 0.3f, 0.2f);
+        preset.flags = static_cast<uint32_t>(ParticleRenderFlagBits::eNoShadow);
         preset.color = glm::vec4(1.0f, 1.0f, 1.0f, 5.0f);
         preset.name = "Flame";
+        preset.particleRandomness = glm::vec3(0.05f, 0.05f, 0.05f);
         SetEmitterPresetImage(preset, image);
-        preset.size.z = -0.4f;
+        preset.size.z = -0.8f;
 
         _emitterPresets.emplace_back(preset);
     }

--- a/engine/particles/public/particle_module.hpp
+++ b/engine/particles/public/particle_module.hpp
@@ -56,9 +56,9 @@ private:
 
     struct EmitterPreset
     {
-        glm::vec3 size = { 1.0f, 1.0f, 0.0f }; // 2d size + velocity
+        glm::vec3 size = { 1.0f, 1.0f, 0.0f }; // 2d size + size velocity
         float mass = 1.0f;
-        glm::vec2 rotationVelocity = { 0.0f, 0.0f }; // angle + velocity
+        glm::vec2 rotationVelocity = { 0.0f, 0.0f }; // angle + angle velocity
         float maxLife = 5.0f;
         float emitDelay = 1.0f;
         uint32_t count = 0;

--- a/engine/particles/public/particle_module.hpp
+++ b/engine/particles/public/particle_module.hpp
@@ -65,6 +65,7 @@ private:
         uint32_t materialIndex = 0;
         glm::vec3 randomness = { 1.0f, 1.0f, 1.0f }; // y is inused as of now for randomness
         uint32_t flags = 0;
+        glm::vec3 particleRandomness = { 0.0f, 0.0f, 0.0f };
         glm::vec4 color = { 1.0f, 1.0f, 1.0f, 1.0f }; // color + color multiplier
         std::string name = "Emitter Preset";
     };

--- a/engine/particles/public/particle_util.hpp
+++ b/engine/particles/public/particle_util.hpp
@@ -11,8 +11,7 @@ static constexpr int32_t MAX_PARTICLES = 1024 * 64;
 enum class ParticleRenderFlagBits : uint8_t
 {
     eUnlit = 1 << 0,
-    eNoShadow = 1 << 1,
-    eSizeOverTime = 1 << 2
+    eNoShadow = 1 << 1
 };
 GENERATE_ENUM_FLAG_OPERATORS(ParticleRenderFlagBits)
 

--- a/engine/particles/public/particle_util.hpp
+++ b/engine/particles/public/particle_util.hpp
@@ -31,6 +31,7 @@ struct alignas(16) Emitter
     glm::vec3 randomness = { 1.0f, 1.0f, 1.0f };
     uint8_t flags = 0;
     glm::vec4 color = { 1.0f, 1.0f, 1.0f, 1.0f };
+    glm::vec3 particleRandomness = { 0.0f, 0.0f, 0.0f };
 };
 
 struct alignas(16) Particle
@@ -45,6 +46,7 @@ struct alignas(16) Particle
     glm::vec3 size = { 1.0f, 1.0f, 0.0f };
     uint8_t flags = 0;
     glm::vec3 color = { 1.0f, 1.0f, 1.0f };
+    glm::vec3 randomness = { 0.0f, 0.0f, 0.0f };
 };
 
 struct alignas(16) ParticleCounters

--- a/shaders/particles/emit.comp
+++ b/shaders/particles/emit.comp
@@ -16,6 +16,7 @@ struct Emitter
     vec3 randomness;
     uint flags;
     vec4 color;
+    vec3 particleRandomness;
 };
 
 const uint MAX_EMITTERS = 256;
@@ -53,6 +54,7 @@ void main()
     particle.size = emitter.size;
     particle.flags = emitter.flags;
     particle.color = emitter.color.xyz * emitter.color.w;
+    particle.randomness = emitter.particleRandomness;
 
     // new particle index retrieved from dead list
     uint deadCount = atomicAdd(particleCounters.deadCount, -1);

--- a/shaders/particles/emit.comp
+++ b/shaders/particles/emit.comp
@@ -40,13 +40,13 @@ void main()
     if (index >= emitter.count)
     return;
 
-    vec2 rng = hash_simplex_2D(vec2(float(index), emitter.randomValue));
+    vec3 rng = snoise3(vec3(float(index), emitter.randomValue, particleCounters.deadCount));
 
     // test particle variables
     Particle particle;
     particle.position = emitter.position;
     particle.mass = emitter.mass;
-    particle.velocity = vec3(emitter.velocity.x + emitter.randomness.x * rng.x, emitter.velocity.y, emitter.velocity.z + emitter.randomness.z * rng.y);// TODO: add something to make this more random?
+    particle.velocity = vec3(emitter.velocity.x + emitter.randomness.x * rng.x, emitter.velocity.y + emitter.randomness.y, emitter.velocity.z + emitter.randomness.z * rng.y);// TODO: add something to make this more random?
     particle.maxLife = emitter.maxLife;
     particle.rotationVelocity = emitter.rotationVelocity;
     particle.life = emitter.maxLife;

--- a/shaders/particles/particle_vars.glsl
+++ b/shaders/particles/particle_vars.glsl
@@ -17,6 +17,7 @@ struct Particle
     vec3 size;
     uint flags;
     vec3 color;
+    vec3 randomness;
 };
 
 struct ParticleCounters

--- a/shaders/particles/particle_vars.glsl
+++ b/shaders/particles/particle_vars.glsl
@@ -3,7 +3,6 @@ const uint MAX_PARTICLES = 1024 * 64;
 // particle rendering flags
 const uint UNLIT = 1 << 0;
 const uint NOSHADOW = 1 << 1;
-const uint SIZEOVERTIME = 1 << 2;
 
 struct Particle
 {

--- a/shaders/particles/rng_helper.glsl
+++ b/shaders/particles/rng_helper.glsl
@@ -1,23 +1,156 @@
 // https://www.shadertoy.com/view/Msf3WH
-vec2 hash_simplex_2D(vec2 p) // replace this by something better
+vec2 hash_simplex_2D(vec2 p)
 {
     p = vec2(dot(p, vec2(127.1, 311.7)), dot(p, vec2(269.5, 183.3)));
     return -1.0 + 2.0 * fract(sin(p) * 43758.5453123);
 }
 
-float HashFloat(uint seed) {
-    seed ^= 2747636419u;
-    seed *= 2654435769u;
-    seed ^= seed >> 16;
-    seed *= 2654435769u;
-    seed ^= seed >> 16;
-    return (float(seed & 0x007FFFFFu) / 0x007FFFFF); // Normalize to [0,1)
+
+// https://thebookofshaders.com/10/
+float random (vec2 p) {
+    return fract(sin(dot(p.xy,
+    vec2(12.9898, 78.233)))*
+    43758.5453123);
 }
 
-vec3 HashVec3(uint seed) {
-    return vec3(
-    HashFloat(seed),
-    HashFloat(seed * 31u + 1u), // Perturb the seed with a prime number
-    HashFloat(seed * 127u + 19u) // Perturb with a different prime
-    );
+
+// https://lygia.xyz (non-commercial use)
+vec3 random3(vec2 p) {
+    vec3 p3 = fract(vec3(p.xyx) * vec3(443.897, 441.423, .0973));
+    p3 += dot(p3, p3.yxz + 19.19);
+    return fract((p3.xxy + p3.yzz) * p3.zyx);
+}
+
+vec3 random3(vec3 p) {
+    p = fract(p * vec3(443.897, 441.423, .0973));
+    p += dot(p, p.yxz + 19.19);
+    return fract((p.xxy + p.yzz) * p.zyx);
+}
+
+vec3 srandom3(vec3 p) {
+    p = vec3(dot(p, vec3(127.1, 311.7, 74.7)),
+    dot(p, vec3(269.5, 183.3, 246.1)),
+    dot(p, vec3(113.5, 271.9, 124.6)));
+    return -1. + 2. * fract(sin(p) * 43758.5453123);
+}
+
+float mod289(const in float x) { return x - floor(x * (1. / 289.)) * 289.; }
+vec2 mod289(const in vec2 x) { return x - floor(x * (1. / 289.)) * 289.; }
+vec3 mod289(const in vec3 x) { return x - floor(x * (1. / 289.)) * 289.; }
+vec4 mod289(const in vec4 x) { return x - floor(x * (1. / 289.)) * 289.; }
+
+float permute(const in float v) { return mod289(((v * 34.0) + 1.0) * v); }
+vec2 permute(const in vec2 v) { return mod289(((v * 34.0) + 1.0) * v); }
+vec3 permute(const in vec3 v) { return mod289(((v * 34.0) + 1.0) * v); }
+vec4 permute(const in vec4 v) { return mod289(((v * 34.0) + 1.0) * v); }
+
+float taylorInvSqrt(in float r) { return 1.79284291400159 - 0.85373472095314 * r; }
+vec2 taylorInvSqrt(in vec2 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+vec3 taylorInvSqrt(in vec3 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+vec4 taylorInvSqrt(in vec4 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+
+float snoise(in vec3 v) {
+    const vec2  C = vec2(1.0/6.0, 1.0/3.0);
+    const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
+
+    // First corner
+    vec3 i  = floor(v + dot(v, C.yyy));
+    vec3 x0 =   v - i + dot(i, C.xxx);
+
+    // Other corners
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min(g.xyz, l.zxy);
+    vec3 i2 = max(g.xyz, l.zxy);
+
+    //   x0 = x0 - 0.0 + 0.0 * C.xxx;
+    //   x1 = x0 - i1  + 1.0 * C.xxx;
+    //   x2 = x0 - i2  + 2.0 * C.xxx;
+    //   x3 = x0 - 1.0 + 3.0 * C.xxx;
+    vec3 x1 = x0 - i1 + C.xxx;
+    vec3 x2 = x0 - i2 + C.yyy;// 2.0*C.x = 1/3 = C.y
+    vec3 x3 = x0 - D.yyy;// -1.0+3.0*C.x = -0.5 = -D.y
+
+    // Permutations
+    i = mod289(i);
+    vec4 p = permute(permute(permute(
+    i.z + vec4(0.0, i1.z, i2.z, 1.0))
+    + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+    + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+    // Gradients: 7x7 points over a square, mapped onto an octahedron.
+    // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
+    float n_ = 0.142857142857;// 1.0/7.0
+    vec3  ns = n_ * D.wyz - D.xzx;
+
+    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);//  mod(p,7*7)
+
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_);// mod(j,N)
+
+    vec4 x = x_ *ns.x + ns.yyyy;
+    vec4 y = y_ *ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+
+    vec4 b0 = vec4(x.xy, y.xy);
+    vec4 b1 = vec4(x.zw, y.zw);
+
+    //vec4 s0 = vec4(lessThan(b0,0.0))*2.0 - 1.0;
+    //vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0;
+    vec4 s0 = floor(b0)*2.0 + 1.0;
+    vec4 s1 = floor(b1)*2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+
+    vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy;
+    vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww;
+
+    vec3 p0 = vec3(a0.xy, h.x);
+    vec3 p1 = vec3(a0.zw, h.y);
+    vec3 p2 = vec3(a1.xy, h.z);
+    vec3 p3 = vec3(a1.zw, h.w);
+
+    //Normalise gradients
+    vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+    // Mix final noise value
+    vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+    m = m * m;
+    return 42.0 * dot(m*m, vec4(dot(p0, x0), dot(p1, x1),
+    dot(p2, x2), dot(p3, x3)));
+}
+
+vec3 snoise3(vec3 x){
+    float s  = snoise(vec3(x));
+    float s1 = snoise(vec3(x.y - 19.1, x.z + 33.4, x.x + 47.2));
+    float s2 = snoise(vec3(x.z + 74.2, x.x - 124.5, x.y + 99.4));
+    return vec3(s, s1, s2);
+}
+
+vec3 curl(vec3 p){
+    const float e = .1;
+    vec3 dx = vec3(e, 0.0, 0.0);
+    vec3 dy = vec3(0.0, e, 0.0);
+    vec3 dz = vec3(0.0, 0.0, e);
+
+    vec3 p_x0 = snoise3(p - dx);
+    vec3 p_x1 = snoise3(p + dx);
+    vec3 p_y0 = snoise3(p - dy);
+    vec3 p_y1 = snoise3(p + dy);
+    vec3 p_z0 = snoise3(p - dz);
+    vec3 p_z1 = snoise3(p + dz);
+
+    float x = p_y1.z - p_y0.z - p_z1.y + p_z0.y;
+    float y = p_z1.x - p_z0.x - p_x1.z + p_x0.z;
+    float z = p_x1.y - p_x0.y - p_y1.x + p_y0.x;
+
+    const float divisor = 1.0 / (2.0 * e);
+    #ifndef CURL_UNNORMALIZED
+    return normalize(vec3(x, y, z) * divisor);
+    #else
+    return vec3(x, y, z) * divisor;
+    #endif
 }

--- a/shaders/particles/simulate.comp
+++ b/shaders/particles/simulate.comp
@@ -39,29 +39,23 @@ void main()
 
     if (particle.life > 0)
     {
-        // simulate size over lifetime
-        if ((particle.flags & SIZEOVERTIME) != SIZEOVERTIME)
-        {
-            particle.size.xy = mix(vec2(0.0, 0.0), particle.size.xy, particle.life / particle.maxLife);
-        }
-        else
-        {
-            particle.size.xy += vec2(particle.size.z) * deltaTime;
-        }
-
+        // simulate size
+        particle.size.xy += vec2(particle.size.z) * deltaTime;
         if ((particle.size.x < 0) || (particle.size.y < 0))
         {
-            // add to dead buffer
+            // add to dead buffer if too small
             uint deadIndex = atomicAdd(particleCounters.deadCount, 1);
             deadBuffer[deadIndex] = particleIndex;
             return;
         }
 
-        // simulate particles
-        particle.velocity.y -= particle.mass;
-        vec2 rng = hash_simplex_2D(vec2(float(index), particle.life / deltaTime));
-        particle.velocity.x += particle.randomness.x * rng.x;
-        particle.velocity.z += particle.randomness.z * rng.y;
+        // simulate movement
+        vec3 force = vec3(0.0);
+        force.y -= particle.mass;
+        vec3 rng = snoise3(vec3(float(index), particle.life / particle.maxLife, deltaTime));
+        force += particle.randomness * rng;
+
+        particle.velocity += force;
         particle.position += particle.velocity * deltaTime;
 
         // simulate angle

--- a/shaders/particles/simulate.comp
+++ b/shaders/particles/simulate.comp
@@ -2,6 +2,7 @@
 
 #include "../scene.glsl"
 #include "particle_binds.glsl"
+#include "rng_helper.glsl"
 
 layout (set = 2, binding = 0) buffer CulledInstancesSSB
 {
@@ -57,7 +58,10 @@ void main()
         }
 
         // simulate particles
-        particle.velocity.y -= particle.mass * deltaTime;
+        particle.velocity.y -= particle.mass;
+        vec2 rng = hash_simplex_2D(vec2(float(index), particle.life / deltaTime));
+        particle.velocity.x += particle.randomness.x * rng.x;
+        particle.velocity.z += particle.randomness.z * rng.y;
         particle.position += particle.velocity * deltaTime;
 
         // simulate angle


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

https://github.com/user-attachments/assets/a43bf540-05c5-49d4-8263-db77dbec7c42

- [ ] Added more pseudo random functions in rng_helpers.glsl
- [ ] Applied 3D noise functions to both randomizing initial spawning velocity, and randomizing part of the force during simulation
- [ ] Added randomness variables that can be tweaked in the preset and emitter editors to somewhat control the randomness
- [ ] Removed size over time simulation as this wasn't adding much and was the cause of the bug with the dust particle

### Issues

None, but part of https://bubonic-brotherhood.codecks.io/milestones/run/57/card/1a6-improved-particle-spawning-and-movement-behavior was finished.

### Test criteria

- [ ] Check if bug with dust particle still occurs where it covers half the screen.
- [ ] Open up one of the fire emitter's editors and tweak the randomness a little to check if it gets more random

Open for any ideas/suggestions for changes to the behavior. There's for example some question marks on how to get certain particles to be random but within certain bounds (like: the fire can move down sometimes when movement randomness on the y-axis is high enough).
