### PR TITLE
fix/WrenMemoryTrackingBug

### DIFF
--- a/engine/scripting/private/scripting_context.cpp
+++ b/engine/scripting/private/scripting_context.cpp
@@ -1,6 +1,7 @@
 #include "scripting_context.hpp"
 #include "file_io.hpp"
 #include "log.hpp"
+#include "profile_macros.hpp"
 
 #include <filesystem>
 

--- a/engine/scripting/private/scripting_context.cpp
+++ b/engine/scripting/private/scripting_context.cpp
@@ -4,7 +4,7 @@
 
 #include <filesystem>
 
-namespace ScriptLoading
+namespace detail
 {
 std::string ResolveImport(
     const std::vector<std::string>& paths,
@@ -42,6 +42,23 @@ std::string LoadFile(const std::string& path)
     }
     throw wren::NotFound();
 }
+
+void* ReallocFn(void* prev, size_t size, MAYBE_UNUSED void* user)
+{
+    TracyFree(prev);
+
+    if (size == 0)
+    {
+        std::free(prev);
+        return nullptr;
+    }
+
+    auto* result = std::realloc(prev, size);
+    TracyAlloc(result, size);
+
+    return result;
+}
+
 }
 
 ScriptingContext::ScriptingContext(const VMInitConfig& info)
@@ -67,13 +84,14 @@ void ScriptingContext::Reset()
         _vmInitConfig.includePaths,
         _vmInitConfig.initialHeapSize,
         _vmInitConfig.minHeapSize,
-        _vmInitConfig.heapGrowthPercent);
+        _vmInitConfig.heapGrowthPercent,
+        detail::ReallocFn);
 
     _vm->setPrintFunc([this](const char* message)
         { *this->_wrenOutStream << message; });
 
-    _vm->setPathResolveFunc(ScriptLoading::ResolveImport);
-    _vm->setLoadFileFunc(ScriptLoading::LoadFile);
+    _vm->setPathResolveFunc(detail::ResolveImport);
+    _vm->setLoadFileFunc(detail::LoadFile);
 }
 
 std::optional<std::string> ScriptingContext::RunScript(const std::string& path)
@@ -83,7 +101,7 @@ std::optional<std::string> ScriptingContext::RunScript(const std::string& path)
     try
     {
         _vm->runFromModule(correctedPath);
-        return ScriptLoading::ResolveImport(_vmInitConfig.includePaths, "", correctedPath);
+        return detail::ResolveImport(_vmInitConfig.includePaths, "", correctedPath);
     }
     catch (const wren::Exception& e)
     {


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

This pull request fixes an issue with the wren vm that does not track allocations and reallocations with Tracy. This causes other allocations to happen where previous wren objects were allocated, which confuses Tracy.

### Issues

None

### Test criteria

- [x] Run tracy on PC a couple times and check if there are any memory leak warnings
