### PR TITLE
Feature/warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ include(scripts/cmake/code-modules.cmake)
 
 ### COMPILATION SETTINGS ###
 
-option(WARNINGS_AS_ERRORS "Enable warnings as errors" OFF)
+option(WARNINGS_AS_ERRORS "Enable warnings as errors" ON)
 
 option(COMPILE_TESTS "Compile with Unit Tests" ON)
 option(COMPILE_SHADERS "Compile all GLSL shaders as part of build step" ON)

--- a/engine/physics/private/systems/physics_system.cpp
+++ b/engine/physics/private/systems/physics_system.cpp
@@ -32,8 +32,7 @@ entt::entity PhysicsSystem::LoadNodeRecursive(const CPUModel& models, ECSModule&
     const Hierarchy& hierarchy,
     entt::entity parent, PhysicsShapes shape)
 {
-
-    if (const bool validation = shape != eMESH && shape != eCONVEXHULL)
+    if (MAYBE_UNUSED const bool validation = shape != eMESH && shape != eCONVEXHULL)
     {
         assert(!validation && "Shape is not supported, please use eMESH or eCONVEXHULL");
         bblog::error("Shape is not supported, please use eMESH or eCONVEXHULL");

--- a/engine/renderer/private/vulkan_context.cpp
+++ b/engine/renderer/private/vulkan_context.cpp
@@ -8,7 +8,6 @@
 #include "pipeline_builder.hpp"
 #include "swap_chain.hpp"
 #include "vulkan_helper.hpp"
-#include "vulkan_include.hpp"
 #include "vulkan_validation.hpp"
 
 VulkanContext::VulkanContext(const VulkanInitInfo& initInfo)

--- a/engine/renderer/public/single_time_commands.hpp
+++ b/engine/renderer/public/single_time_commands.hpp
@@ -6,7 +6,8 @@
 #include <memory>
 #include <vector>
 #include <vk_mem_alloc.h>
-#include <vulkan/vulkan.hpp>
+
+#include "vulkan_include.hpp"
 
 class GraphicsContext;
 struct Texture;


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Enabled warnings as errors. Also fixes the warnings we already had.
The warnings are already considered as errors in our CI/CD, so I didn't have to change anything there (which somehow didn't detect 2 warnings we had).

### Issues

[Codecks card](https://bubonic-brotherhood.codecks.io/milestones/run/57/card/1o4-warnings-as-errors)

### Test criteria

- [ ] The project should compile successfully
