### PR TITLE
Loading model from scripts

### DIFF
--- a/engine/bindings/private/wren_bindings.cpp
+++ b/engine/bindings/private/wren_bindings.cpp
@@ -5,6 +5,7 @@
 #include "audio_module.hpp"
 #include "ecs_module.hpp"
 #include "entity/entity_bind.hpp"
+#include "entity/wren_entity.hpp"
 #include "game/game_bindings.hpp"
 #include "game_module.hpp"
 #include "input/input_bindings.hpp"
@@ -15,14 +16,12 @@
 #include "physics/physics_bindings.hpp"
 #include "physics_module.hpp"
 #include "renderer/animation_bindings.hpp"
-//#include "renderer/renderer_bindings.hpp"
 #include "renderer_module.hpp"
 #include "scene/scene_loader.hpp"
 #include "scripting_module.hpp"
 #include "time_module.hpp"
 #include "utility/math_bind.hpp"
 #include "wren_engine.hpp"
-#include "entity/wren_entity.hpp"
 
 namespace bindings
 {
@@ -44,7 +43,7 @@ std::vector<WrenEntity> LoadModelScripting(WrenEngine& engine, const std::string
 
     auto& registry = engine.GetModule<ECSModule>().value()->GetRegistry();
 
-    for(size_t i = 0; i < entities.size(); i++)
+    for (size_t i = 0; i < entities.size(); i++)
     {
         wrentities[i].entity = entities[i];
         wrentities[i].registry = &registry;
@@ -109,11 +108,6 @@ void BindEngineAPI(wren::ForeignModule& module)
     // Physics
     {
         BindPhysicsAPI(module);
-    }
-
-    // Renderer
-    {
-        //BindRendererAPI(module);
     }
 
     // Pathfinding

--- a/game/game.wren
+++ b/game/game.wren
@@ -72,6 +72,11 @@ class Main {
 
         __rayDistance = 1000.0
         __rayDistanceVector = Vec3.new(__rayDistance, __rayDistance, __rayDistance)
+
+        var enemyEntity = engine.LoadModel("assets/models/demon.glb")[0]
+        var enemyTransform = enemyEntity.GetTransformComponent()
+        enemyTransform.scale = Vec3.new(0.03, 0.03, 0.03)
+        enemyTransform.translation = Vec3.new(4.5, 35.0, 285.0)
     }
 
     static Shutdown(engine) {


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [x] I have looked at and updated the related issues in Codecks

### Description

Added the ability to load models from scripting which is just a passthrough from [SceneLoading::LoadModels](https://github.com/BredaUniversityGames/Y2024-25-PR-BB/blob/28fa94b262e1a22e0bcd318b4d2ecfb97de4d5fe/engine/game/private/scene/scene_loader.cpp#L174) call

### Test criteria

The scripting engine shouldn't throw any errors.
When playing the game the demon model should be placed on the player's spawn area. Corresponding to the below image:
![image](https://github.com/user-attachments/assets/e45bcf4f-8587-45ac-a734-a2625d679ed6)

