### PR TITLE
fix/bloom-sampler

### DIFF
--- a/engine/game/private/game_module.cpp
+++ b/engine/game/private/game_module.cpp
@@ -91,7 +91,6 @@ void GameModule::Tick(MAYBE_UNUSED Engine& engine)
     auto& physicsModule = engine.GetModule<PhysicsModule>();
     auto& audioModule = engine.GetModule<AudioModule>();
     auto& pathfindingModule = engine.GetModule<PathfindingModule>();
-    auto& scriptingModule = engine.GetModule<ScriptingModule>();
 
     // Slow down application when minimized.
     if (applicationModule.isMinimized())

--- a/engine/renderer/private/renderer.cpp
+++ b/engine/renderer/private/renderer.cpp
@@ -480,11 +480,21 @@ void Renderer::InitializeHDRTarget()
 
 void Renderer::InitializeBloomTargets()
 {
+    auto& samplerResourceManager = _context->Resources()->SamplerResourceManager();
+    SamplerCreation samplerCreation {
+        .name = "Bloom Sampler",
+        .mipmapMode = vk::SamplerMipmapMode::eLinear,
+        .minLod = 0.0f,
+        .maxLod = vk::LodClampNone,
+    };
+    samplerCreation.SetGlobalAddressMode(vk::SamplerAddressMode::eClampToEdge);
+    _bloomSampler = samplerResourceManager.Create(samplerCreation);
+
     auto size = _swapChain->GetImageSize();
 
     CPUImage bloomCreation {};
     bloomCreation.SetName("HDR Bloom Target").SetSize(size.x, size.y).SetMips(4).SetFormat(vk::Format::eR16G16B16A16Sfloat).SetFlags(vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eSampled);
-    _bloomTarget = _context->Resources()->ImageResourceManager().Create(bloomCreation);
+    _bloomTarget = _context->Resources()->ImageResourceManager().Create(bloomCreation, _bloomSampler);
 }
 void Renderer::InitializeTonemappingTarget()
 {

--- a/engine/renderer/public/renderer.hpp
+++ b/engine/renderer/public/renderer.hpp
@@ -108,6 +108,8 @@ private:
     ResourceHandle<GPUImage> _tonemappingTarget;
     ResourceHandle<GPUImage> _fxaaTarget;
 
+    ResourceHandle<Sampler> _bloomSampler;
+
     std::unique_ptr<FrameGraph> _frameGraph;
     std::unique_ptr<SwapChain> _swapChain;
     std::unique_ptr<GBuffers> _gBuffers;


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [x] I have looked at and updated the related issues in Codecks

### Description

Before bloom could leak onto the other side of the screen:
![before](https://github.com/user-attachments/assets/03b65628-e5b6-4748-8f68-be59385f5508)

Now that doesn't happen anymore:
![after](https://github.com/user-attachments/assets/75e52f8d-e739-4a48-86ef-f3a018de823d)

### Test criteria

- [x] When bloom strength is a high number, it no longer leaks onto the other side of the screen
