### PR TITLE
[Fix] Linter warnings in CI/CD

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -50,7 +50,7 @@ jobs:
 
           version: 18
           files-changed-only: true # Only processes files changed in PR
-          database: build/WSL-Release/compile_commands.json
+          database: build/WSL-Distribution/compile_commands.json
           verbosity: 'debug'
           style: 'file'
           ignore: 'external | build | VULKAN_SDK' # Also ignore Vulkan SDK folder


### PR DESCRIPTION
### Reviewer steps

Fixes mini issue in linter: the wrong compile_commands.json was selected.
