### PR TITLE
Feature/game version setting

### DIFF
--- a/.github/workflows/steam-build-upload.yml
+++ b/.github/workflows/steam-build-upload.yml
@@ -143,6 +143,11 @@ jobs:
           name: linux-dist
           path: package/
 
+      # Update game version
+      - name: Write Game Version
+        run: |
+          "Blightspire - Build ${{ github.ref_name }}" > "version.txt"
+
       # Create steam config to avoid 2FA
 
       - name: Create Steam Config


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

The Steam upload pipeline now sets the game version in the version.txt file to be displayed in the game based on the release tag.

### Issues

[codecks card](https://bubonic-brotherhood.codecks.io/milestones/run/65/card/1re-game-version-setting)

### Test criteria

To test this functionality I need to merge this and create a test release to check if it works.
