### PR TITLE
[FIX] Camera yaw locked

### DIFF
--- a/game/gameplay/movement.wren
+++ b/game/gameplay/movement.wren
@@ -115,7 +115,6 @@ class PlayerMovement{
         _cameraYaw = Math.Min(Math.Max(_cameraYaw + rotationDelta.y, Math.Radians(-90.0)), Math.Radians(90.0))
         var forwardVector = Math.ToQuat(Vec3.new(_cameraYaw, -_cameraPitch, 0))
 
-
         var gun = engine.GetECS().GetEntityByName("Gun")
         var gunTransform = gun.GetTransformComponent()
 
@@ -125,16 +124,13 @@ class PlayerMovement{
         _smoothedCameraDelta.x = (_smoothedCameraDelta.x * lerpFactor +  rotationDelta.x * (1-lerpFactor)) / divisionFactor
         _smoothedCameraDelta.y = (_smoothedCameraDelta.y * lerpFactor +  rotationDelta.y * (1-lerpFactor)) / divisionFactor
 
-
         var clampedX  = Math.Clamp(_smoothedCameraDelta.x*5,-max,max)
         var clampedY  = Math.Clamp(_smoothedCameraDelta.y*5,-max,max)
 
         gunTransform.translation = Vec3.new(clampedX,clampedY,0)
         gunTransform.rotation = Math.ToQuat(Vec3.new(0,-Math.PI()/2+clampedX,clampedY*0.2)) 
 
-        var rotation = forwardVector
-
-        player.GetTransformComponent().rotation = rotation
+        player.GetTransformComponent().rotation = forwardVector
     }
 
     FlyCamMovement(engine, player) {

--- a/game/gameplay/movement.wren
+++ b/game/gameplay/movement.wren
@@ -22,6 +22,9 @@ class PlayerMovement{
         slideForce = 3.0
         slideWishDirection = Vec3.new(0.0,0.0,0.0)
         
+        _cameraPitch = 0.0
+        _cameraYaw = 0.0
+
         dashWishPosition = Vec3.new(0.0,0.0,0.0)
         dashForce = 6.0
         currentDashCount = 3
@@ -108,18 +111,10 @@ class PlayerMovement{
         rotationDelta.x = rotationDelta.x + lookAnalogAction.x * GAMEPAD_LOOK_SENSITIVITY * dt
         rotationDelta.y = rotationDelta.y + lookAnalogAction.y * GAMEPAD_LOOK_SENSITIVITY * dt
 
-        var rotation = player.GetTransformComponent().rotation
+        _cameraPitch = _cameraPitch + rotationDelta.x
+        _cameraYaw = Math.Min(Math.Max(_cameraYaw + rotationDelta.y, Math.Radians(-90.0)), Math.Radians(90.0))
+        var forwardVector = Math.ToQuat(Vec3.new(_cameraYaw, -_cameraPitch, 0))
 
-        var euler = Math.ToEuler(rotation)
-        euler.x = euler.x + rotationDelta.y
-
-        var cameraForward = FORWARD.mulQuat(rotation).normalize()
-
-        if (cameraForward.z > 0.0) {
-            euler.y = euler.y + rotationDelta.x
-        } else {
-            euler.y = euler.y - rotationDelta.x
-        }
 
         var gun = engine.GetECS().GetEntityByName("Gun")
         var gunTransform = gun.GetTransformComponent()
@@ -132,11 +127,12 @@ class PlayerMovement{
 
 
         var clampedX  = Math.Clamp(_smoothedCameraDelta.x*5,-max,max)
-        var clampedY  = Math.Clamp(_smoothedCameraDelta.y*5,-max,max) 
+        var clampedY  = Math.Clamp(_smoothedCameraDelta.y*5,-max,max)
 
         gunTransform.translation = Vec3.new(clampedX,clampedY,0)
         gunTransform.rotation = Math.ToQuat(Vec3.new(0,-Math.PI()/2+clampedX,clampedY*0.2)) 
-        rotation = Math.ToQuat(euler)
+
+        var rotation = forwardVector
 
         player.GetTransformComponent().rotation = rotation
     }


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Changed camera system to rely on pitch and yaw values to determine the forward vector and clamp the camera to avoid flipping the horizon

![ClampedCamera](https://github.com/user-attachments/assets/300f227b-630e-4f5e-aca6-ab1e714ab766)


### Issues

https://bubonic-brotherhood.codecks.io/milestones/run/65/card/1e3-clamping-camera-no-longer-works

### Test criteria

Moving the camera around should behave the exact same way as before, save for the change that the camera yaw is now clamped to prevent flipping backwards
