### PR TITLE
[FIXED] Removing unnecessary characters from game version text

### DIFF
--- a/engine/game/private/ui/game_version.cpp
+++ b/engine/game/private/ui/game_version.cpp
@@ -9,7 +9,11 @@ std::shared_ptr<GameVersionVisualization> GameVersionVisualization::Create(Graph
 
     visualization->SetAbsoluteTransform(visualization->GetAbsoluteLocation(), screenResolution);
 
-    visualization->text = visualization->AddChild<UITextElement>(font, text, glm::vec2(10.0f, 50.0f), 50);
+    std::string cleanText = text;
+    cleanText.erase(std::remove(cleanText.begin(), cleanText.end(), '\n'), cleanText.end()); // Remove any new line
+    cleanText.erase(std::remove(cleanText.begin(), cleanText.end(), '\r'), cleanText.end()); // Remove any alignment
+
+    visualization->text = visualization->AddChild<UITextElement>(font, cleanText, glm::vec2(10.0f, 50.0f), 50);
     visualization->text.lock()->anchorPoint = UIElement::AnchorPoint::eBottomLeft;
     visualization->text.lock()->SetColor(glm::vec4(0.75f, 0.75f, 0.75f, 0.75f));
 


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Fixed the invisible character in the game version text.

Before:
![image](https://github.com/user-attachments/assets/aaa80b62-9a5e-4ebb-8071-427cc215127f)

After:
![image](https://github.com/user-attachments/assets/f4523f6a-7088-4709-9326-957e9a7a0674)

### Issues

[Codecks card](https://bubonic-brotherhood.codecks.io/decks/6-qa/card/1wa-invisible-character-present-in-game-version-which-breaks-the-visualization-in)

### Test criteria

- [x] Copy the text `version.txt` file from Steam build into the project directory and run the project to check if the character is removed (Or just put an enter in the existing file, same thing)