### PR TITLE
[FIX] Decals spawning on dead enemies

### DIFF
--- a/game/gameplay/weapon.wren
+++ b/game/gameplay/weapon.wren
@@ -1,4 +1,4 @@
-import "engine_api.wren" for Engine, ECS, Entity, Vec3, Vec2, Math, AnimationControlComponent, TransformComponent, Input, SpawnEmitterFlagBits, EmitterPresetID
+import "engine_api.wren" for Engine, ECS, Entity, Vec3, Vec2, Math, AnimationControlComponent, TransformComponent, Input, SpawnEmitterFlagBits, EmitterPresetID, PhysicsObjectLayer
 import "camera.wren" for CameraVariables
 import "player.wren" for PlayerVariables
 
@@ -153,7 +153,9 @@ class Pistol {
                             }
                             break
                         }
-                        engine.SpawnDecal(normal, end, Vec2.new(0.001, 0.001), "bullet_hole.png")
+                        if(hitEntity.GetRigidbodyComponent().GetLayer() == PhysicsObjectLayer.eSTATIC()) {
+                            engine.SpawnDecal(normal, end, Vec2.new(0.001, 0.001), "bullet_hole.png")
+                        }
                         break
                     }
                 }


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

- Instead of checking for tags, check if mesh hit is in static layer

### Issues

https://bubonic-brotherhood.codecks.io/card/1w4-decals-appearing-on-dynamic-meshes

### Test criteria

- [ ] Kill an enemy and while their death animation is playing, shoot at them again and check if a decal appears
