### PR TITLE
New velocity based dash

### DIFF
--- a/game/game.wren
+++ b/game/game.wren
@@ -417,6 +417,6 @@ class Main {
             }
         }
 
-        __waveSystem.Update(dt)
+        //__waveSystem.Update(dt)
     }
 }


### PR DESCRIPTION
### Reviewer steps

- [x] I can build the project locally
- [x] I have tested and approved the features from this pull request
- [x] I have checked and approved the test criteria
- [x] I have reviewed the files in the pull request
- [x] I have looked at and updated the related issues in Codecks

### Description

This PR introduces the reworked dash that works with velocity. Clipping through the ground should no longer happen when dashing.

This also fixes the crash that would happen sometimes when you dashed backwards.

### Issues

https://bubonic-brotherhood.codecks.io/decks/46-gameplay/card/1xw-velocity-based-dash

### Test criteria

- [x] Let me know how it feels during gameplay
- [x] See if you can still glitch through the map
