### PR TITLE
[FIXED] Rendering bloom on sky

### DIFF
--- a/shaders/tonemapping.frag
+++ b/shaders/tonemapping.frag
@@ -152,7 +152,8 @@ void main()
         hdrColor = ComputeQuantizedColor(hdrColor, pc.ditherAmount, pc.paletteAmount);
     }
 
-    hdrColor += bloomColor * bloomSettings.strength;
+    vec3 bloom = bloomColor * bloomSettings.strength;
+    hdrColor += bloom;
     vec3 color = vec3(1.0) - exp(-hdrColor * pc.exposure);
 
     //sample the depth again, maybe we now need to use pixelization
@@ -177,6 +178,8 @@ void main()
         {
             color = ComputeQuantizedColor(color, pc.ditherAmount, pc.paletteAmount);
         }
+
+        color += bloom;
     }
 
     switch (pc.tonemappingFunction)


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Fixed a bug where bloom was not rendered properly when the sky was in the background.

Before:
![image](https://github.com/user-attachments/assets/dd68ec4d-b55d-447e-b747-68ec1213f1fa)

After:
![image](https://github.com/user-attachments/assets/a86eb76f-963d-410d-a786-aeb9167f4b7b)

### Test criteria

- [ ] The bloom should be rendered from bright objects when the sky is in the background of such object
