### PR TITLE
sync enemy damage to animation

### DIFF
--- a/game/gameplay/enemies/berserker_enemy.wren
+++ b/game/gameplay/enemies/berserker_enemy.wren
@@ -187,12 +187,11 @@ class BerserkerEnemy {
 
                             flashSystem.Flash(Vec3.new(1.0, 0.0, 0.0),0.85)
                             engine.GetAudio().PlayEventOnce(_hitSFX)
-                        }
-
-                        animations.Play("Idle", 1.0, true, 1.0, false)
-                        animations.SetTime(0.0)
+                        }    
                     }
 
+                    animations.Play("Idle", 1.0, true, 1.0, false)
+                    animations.SetTime(0.0)
                     _attackTimer = 999999
                 }
 
@@ -244,6 +243,10 @@ class BerserkerEnemy {
                     _attackingState = true
                     _movingState = false
                     body.SetFriction(12.0)
+                    _attackTimer = _attackTiming 
+                    if (animations.CurrentAnimationName() == "Walk") {
+                        _attackTimer = _attackTimer - 100
+                    }
                     animations.Play("Swipe", 1.0, false, 0.3, false)
                     animations.SetTime(0.0)
                     _attackTime = _attackMaxTime


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Synced enemy attacks to match their animation

### Issues

https://bubonic-brotherhood.codecks.io/card/1yz-sync-attack-animation-to-damage

### Test criteria

- [ ] play the game and get hit by the enemies and see if the animation matches the damage
