### PR TITLE
Enemy attack occlusion check 

### DIFF
--- a/game/gameplay/enemies/berserker.wren
+++ b/game/gameplay/enemies/berserker.wren
@@ -168,7 +168,7 @@ class BerserkerEnemy {
                         var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange * 5)
+                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange)
                             var isOccluded = false
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {

--- a/game/gameplay/enemies/berserker.wren
+++ b/game/gameplay/enemies/berserker.wren
@@ -173,7 +173,7 @@ class BerserkerEnemy {
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {
                                     var hitEntity = rayHit.GetEntity(engine.GetECS())
-                                    if (hitEntity == _rootEntity) {
+                                    if (hitEntity == _rootEntity || hitEntity.HasEnemyTag()) {
                                         continue
                                     }
                                     if (!hitEntity.HasPlayerTag()) {

--- a/game/gameplay/enemies/berserker.wren
+++ b/game/gameplay/enemies/berserker.wren
@@ -15,7 +15,7 @@ class BerserkerEnemy {
         var modelPath = "assets/models/Berserker.glb"
         var colliderShape = ShapeFactory.MakeCapsuleShape(145.0, 40.0) // TODO: Make this engine units
         
-        _attackRange = 9
+        _attackRange = 6.5
         _attackDamage = 35
         _shakeIntensity = 2.2
         _attackMaxTime = 2300
@@ -164,17 +164,34 @@ class BerserkerEnemy {
                     _rootEntity.GetAudioEmitterComponent().AddEvent(engine.GetAudio().PlayEventOnce(_attackHitSFX))
                     if (!playerVariables.IsInvincible()) {
 
-                        var forward = Math.ToVector(_rootEntity.GetTransformComponent().rotation)
-                        var toPlayer = pos - playerPos
+                        var forward = Math.ToVector(_rootEntity.GetTransformComponent().rotation).mulScalar(-1)
+                        var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            playerVariables.DecreaseHealth(_attackDamage)
-                            playerVariables.cameraVariables.shakeIntensity = _shakeIntensity
-                            playerVariables.invincibilityTime = playerVariables.invincibilityMaxTime
+                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange * 5)
+                            var isOccluded = false
+                            if (!rayHitInfo.isEmpty) {
+                                for (rayHit in rayHitInfo) {
+                                    var hitEntity = rayHit.GetEntity(engine.GetECS())
+                                    if (hitEntity == _rootEntity) {
+                                        continue
+                                    }
+                                    if (!hitEntity.HasPlayerTag()) {
+                                        isOccluded = true
+                                    }
+                                    break
+                                }
+                            }
 
-                            flashSystem.Flash(Vec3.new(1.0, 0.0, 0.0),0.85)
-                            engine.GetAudio().PlayEventOnce(_hitSFX)
-                        }    
+                            if (!isOccluded) {
+                                playerVariables.DecreaseHealth(_attackDamage)
+                                playerVariables.cameraVariables.shakeIntensity = _shakeIntensity
+                                playerVariables.invincibilityTime = playerVariables.invincibilityMaxTime
+
+                                flashSystem.Flash(Vec3.new(1.0, 0.0, 0.0),0.85)
+                                engine.GetAudio().PlayEventOnce(_hitSFX)
+                            }
+                        }
                     }
 
                     animations.Play("Idle", 1.0, true, 1.0, false)
@@ -214,7 +231,7 @@ class BerserkerEnemy {
 
                 if(_walkEventInstance == null || engine.GetAudio().IsEventPlaying(_walkEventInstance) == false) {
                     _walkEventInstance = engine.GetAudio().PlayEventLoop(_stepSFX)
-                    engine.GetAudio().SetEventVolume(_walkEventInstance, 5.0)
+                    engine.GetAudio().SetEventVolume(_walkEventInstance, 1.0)
                     var audioEmitter = _rootEntity.GetAudioEmitterComponent()
                     audioEmitter.AddEvent(_walkEventInstance)
                 }

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -222,7 +222,6 @@ class MeleeEnemy {
                             }
 
                             if (!isOccluded) {
-                                System.print("Playerpos.y = %(playerPos.y - pos.y)")
                                 playerVariables.DecreaseHealth(_attackDamage)
                                 playerVariables.cameraVariables.shakeIntensity = _shakeIntensity
                                 playerVariables.invincibilityTime = playerVariables.invincibilityMaxTime

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -104,7 +104,7 @@ class MeleeEnemy {
     }
 
     IsHeadshot(y) { // Will probably need to be changed when we have a different model
-        if (y >= _rootEntity.GetRigidbodyComponent().GetPosition().y + 0.5) {
+        if (y >= _rootEntity.GetRigidbodyComponent().GetPosition().y + 0.5 && !_getUpState) {
             return true
         }
         return false

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -206,7 +206,7 @@ class MeleeEnemy {
                         var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange * 5)
+                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange)
                             var isOccluded = false
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -10,7 +10,7 @@ class MeleeEnemy {
         
         // ENEMY CONSTANTS
         _maxVelocity = 13
-        _attackRange = 7
+        _attackRange = 4.5
         _attackDamage = 20
         _shakeIntensity = 1.6
         _attackCooldown = 2000
@@ -202,19 +202,37 @@ class MeleeEnemy {
                 if (_attackTimer <= 0 ) {
                     _attackTimer = 999999
                     if (!playerVariables.IsInvincible()) {
-                        var forward = Math.ToVector(_rootEntity.GetTransformComponent().rotation)
-                        var toPlayer = pos - playerPos
+                        var forward = Math.ToVector(_rootEntity.GetTransformComponent().rotation).mulScalar(-1)
+                        var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            playerVariables.DecreaseHealth(_attackDamage)
-                            playerVariables.cameraVariables.shakeIntensity = _shakeIntensity
-                            playerVariables.invincibilityTime = playerVariables.invincibilityMaxTime
+                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange * 5)
+                            var isOccluded = false
+                            if (!rayHitInfo.isEmpty) {
+                                for (rayHit in rayHitInfo) {
+                                    var hitEntity = rayHit.GetEntity(engine.GetECS())
+                                    if (hitEntity == _rootEntity) {
+                                        continue
+                                    }
+                                    if (!hitEntity.HasPlayerTag()) {
+                                        isOccluded = true
+                                    }
+                                    break
+                                }
+                            }
 
-                        //Flash the screen red
-                        flashSystem.Flash(Vec3.new(105 / 255, 13 / 255, 1 / 255),0.75)
+                            if (!isOccluded) {
+                                System.print("Playerpos.y = %(playerPos.y - pos.y)")
+                                playerVariables.DecreaseHealth(_attackDamage)
+                                playerVariables.cameraVariables.shakeIntensity = _shakeIntensity
+                                playerVariables.invincibilityTime = playerVariables.invincibilityMaxTime
 
-                        engine.GetAudio().PlayEventOnce(_hitSFX)
-                        //animations.Play("Attack", 1.0, false, 0.1, false)
+                                //Flash the screen red
+                                flashSystem.Flash(Vec3.new(105 / 255, 13 / 255, 1 / 255),0.75)
+
+                                engine.GetAudio().PlayEventOnce(_hitSFX)
+                                //animations.Play("Attack", 1.0, false, 0.1, false)
+                            }
                         }
                     }
                 }

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -211,7 +211,7 @@ class MeleeEnemy {
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {
                                     var hitEntity = rayHit.GetEntity(engine.GetECS())
-                                    if (hitEntity == _rootEntity) {
+                                    if (hitEntity == _rootEntity || hitEntity.HasEnemyTag()) {
                                         continue
                                     }
                                     if (!hitEntity.HasPlayerTag()) {


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

- Skeletons can no longer be headshot when getting up
- Reduced attack range for berserker and skeleton enemies
- Occlusion checks on berserker and skeleton attacks

### Issues

https://bubonic-brotherhood.codecks.io/card/1zw-skeletons-should-not-be-able-to-be-headshotted-when-getting-up
https://bubonic-brotherhood.codecks.io/card/214-add-attack-occlusion-checks-to-enemies

### Test criteria

- [ ] Try standing behind a wall and have an enemy try to hit you, you should not take damage
