### PR TITLE
Replaced Shoot ray calls with shoot multiple rays

### DIFF
--- a/game/gameplay/enemies/berserker.wren
+++ b/game/gameplay/enemies/berserker.wren
@@ -168,7 +168,7 @@ class BerserkerEnemy {
                         var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange)
+                            var rayHitInfo = engine.GetPhysics().ShootMultipleRays(pos, toPlayer, _attackRange, 3, 20)
                             var isOccluded = false
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -207,7 +207,7 @@ class MeleeEnemy {
                         var toPlayer = (playerPos - pos).normalize()
 
                         if (Math.Dot(forward, toPlayer) >= 0.8 && Math.Distance(playerPos, pos) < _attackRange) {
-                            var rayHitInfo = engine.GetPhysics().ShootRay(pos, toPlayer, _attackRange)
+                            var rayHitInfo = engine.GetPhysics().ShootMultipleRays(pos, toPlayer, _attackRange, 3, 20)
                             var isOccluded = false
                             if (!rayHitInfo.isEmpty) {
                                 for (rayHit in rayHitInfo) {


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

This PR improves on the earlier one made by Leo regarding enemies' occlusion checks when attacking. 

After playing the game a bit, I found out that most of the time the enemies were missing because a small ray is very likely to miss, especially when the player is moving at all times, which makes the game very easy and the enemies really dumb.

This PR calls the built-in ShootMultipleRays to check the occlusion at a cone using 3 rays instead of one.

Note: Don't mind the spam lines, those are from the player ground check

![image](https://github.com/user-attachments/assets/b52995df-948c-43b4-954f-15d45799a80f)


### Issues

None

### Test criteria

- [ ] Does it feel better?
