### PR TITLE
Low health heartbeat, lowpass & vignette, enemy spawn sound, station activate sound

### DIFF
--- a/engine/audio/private/audio_module.cpp
+++ b/engine/audio/private/audio_module.cpp
@@ -40,6 +40,13 @@ ModuleTickOrder AudioModule::Init(MAYBE_UNUSED Engine& engine)
         FMOD_CHECKRESULT(FMOD_Studio_System_GetCoreSystem(_studioSystem, &_coreSystem));
         FMOD_CHECKRESULT(FMOD_System_GetMasterChannelGroup(_coreSystem, &_masterGroup));
 
+        // Lowpass DSP
+        FMOD_CHECKRESULT(FMOD_System_CreateDSPByType(_coreSystem, FMOD_DSP_TYPE_LOWPASS, &_lowPassDSP));
+        FMOD_CHECKRESULT(FMOD_DSP_SetParameterFloat(_lowPassDSP, FMOD_DSP_LOWPASS_CUTOFF, 5000.f));
+        FMOD_CHECKRESULT(FMOD_DSP_SetActive(_lowPassDSP, true));
+        FMOD_CHECKRESULT(FMOD_DSP_SetBypass(_lowPassDSP, true));
+        FMOD_CHECKRESULT(FMOD_ChannelGroup_AddDSP(_masterGroup, FMOD_CHANNELCONTROL_DSP_TAIL, _lowPassDSP));
+
         // FFT DSP for spectrum debug info
         FMOD_CHECKRESULT(FMOD_System_CreateDSPByType(_coreSystem, FMOD_DSP_TYPE_FFT, &_fftDSP));
         FMOD_CHECKRESULT(FMOD_DSP_SetParameterInt(_fftDSP, FMOD_DSP_FFT_WINDOWSIZE, 512));
@@ -242,6 +249,11 @@ void AudioModule::SetBusChannelVolume(const std::string& name, float value)
     {
         bblog::warn("No event bus with the name {}.", name);
     }
+}
+
+void AudioModule::SetLowpassBypass(bool state)
+{
+    FMOD_CHECKRESULT(FMOD_DSP_SetBypass(_lowPassDSP, state));
 }
 
 void AudioModule::UnloadBank(const BankInfo& bankInfo)

--- a/engine/audio/public/audio_module.hpp
+++ b/engine/audio/public/audio_module.hpp
@@ -83,6 +83,8 @@ public:
     void RegisterChannelBus(const std::string& busName);
     void SetBusChannelVolume(const std::string& busName, float scale);
 
+    void SetLowpassBypass(bool state);
+
     std::vector<glm::vec3>& GetDebugLines()
     {
         return _debugLines;
@@ -116,6 +118,7 @@ private:
     // All sounds go through this eventually
     // USED ONLY FOR DSP VISUALIZATION: for events, we use event buses
     FMOD_CHANNELGROUP* _masterGroup = nullptr;
+    FMOD_DSP* _lowPassDSP = nullptr;
     FMOD_DSP* _fftDSP = nullptr;
 
     std::unordered_map<std::string, SoundInfo> _soundInfos {};

--- a/engine/bindings/private/audio/audio_bindings.cpp
+++ b/engine/bindings/private/audio/audio_bindings.cpp
@@ -85,6 +85,16 @@ void SetEventFloatAttribute(AudioModule& self, EventInstance audio, const std::s
     self.SetEventFloatAttribute(audio, name, val);
 }
 
+void EnableLowPass(AudioModule& self)
+{
+    self.SetLowpassBypass(false);
+}
+
+void DisableLowPass(AudioModule& self)
+{
+    self.SetLowpassBypass(true);
+}
+
 }
 
 void BindAudioAPI(wren::ForeignModule& module)
@@ -99,6 +109,8 @@ void BindAudioAPI(wren::ForeignModule& module)
     wren_class.funcExt<bindings::PlayEventLoop>("PlayEventLoop", "Play FMOD event on loop, returns an event instance");
     wren_class.funcExt<bindings::StopEvent>("StopEvent", "Stop playing an event instance");
     wren_class.funcExt<bindings::StopSFX>("StopSFX", "Stop playing a sound effect instance");
+    wren_class.funcExt<&bindings::EnableLowPass>("EnableLowPass", "Enables the lowpass DSP");
+    wren_class.funcExt<&bindings::DisableLowPass>("DisableLowPass", "Disables the lowpass DSP");
     wren_class.func<&AudioModule::SetEventFloatAttribute>("SetEventFloatAttribute", "Pass event instance, attribute name and float value");
     wren_class.func<&AudioModule::SetEventVolume>("SetEventVolume", "Set event volume from 0.0 to 1.0");
 

--- a/game/game.wren
+++ b/game/game.wren
@@ -184,6 +184,12 @@ class Main {
             "event:/BGM/DarkSwampAmbience",
             0.1)
 
+        __heartBeatSFX = "event:/SFX/HeartBeat"
+        __heartBeatEvent = engine.GetAudio().PlayEventLoop(__heartBeatSFX)
+        engine.GetAudio().SetEventVolume(__heartBeatEvent, 4)
+
+        __camera.GetAudioEmitterComponent().AddEvent(__heartBeatEvent)
+
         var spawnLocations = []
         for(i in 0..8) {
             var entity = engine.GetECS().GetEntityByName("Spawner_%(i)")
@@ -308,6 +314,16 @@ class Main {
         } else {
             __musicPlayer.SetAttribute(engine.GetAudio(), "Intensity", 0.0)
         }
+
+        var healthFraction = __playerVariables.health / __playerVariables.maxHealth
+        engine.GetAudio().SetEventFloatAttribute(__heartBeatEvent, "Health", healthFraction)
+        if (healthFraction < 0.3) {
+            engine.GetAudio().EnableLowPass()
+        } else {
+            engine.GetAudio().DisableLowPass()
+        }
+
+        
 
         var cheats = __playerController.GetCheatsComponent()
         var deltaTime = engine.GetTime().GetDeltatime()

--- a/game/game.wren
+++ b/game/game.wren
@@ -318,6 +318,7 @@ class Main {
         var healthFraction = __playerVariables.health / __playerVariables.maxHealth
         engine.GetAudio().SetEventFloatAttribute(__heartBeatEvent, "Health", healthFraction)
         if (healthFraction < 0.3) {
+            __flashSystem.SetBaseColor(Vec3.new(105 / 255, 13 / 255, 1 / 255),2 - healthFraction*4)
             engine.GetAudio().EnableLowPass()
         } else {
             engine.GetAudio().DisableLowPass()

--- a/game/gameplay/enemies/berserker.wren
+++ b/game/gameplay/enemies/berserker.wren
@@ -30,6 +30,7 @@ class BerserkerEnemy {
         _attackSFX = "event:/SFX/DemonAttack"
         _attackHitSFX = "event:/SFX/DemonAttackHit"
         _hitSFX = "event:/SFX/Hit"
+        _spawnSFX = "event:/SFX/EnemySpawn"
 
         // ENTITY SETUP
 
@@ -38,6 +39,10 @@ class BerserkerEnemy {
         _rootEntity.AddNameComponent().name = "BerserkerEnemy"
         _rootEntity.AddEnemyTag()
         _rootEntity.AddAudioEmitterComponent()
+        
+        _delaySpawnSFX = Random.RandomFloatRange(0, 1500)
+        _playedSpawnSFX = false
+
         var transform = _rootEntity.AddTransformComponent()
         transform.translation = spawnPosition
         transform.scale = Vec3.new(enemySize, enemySize, enemySize)
@@ -154,6 +159,12 @@ class BerserkerEnemy {
         var pos = body.GetPosition()
         var animations = _meshEntity.GetAnimationControlComponent()
 
+    	_delaySpawnSFX = Math.Max(_delaySpawnSFX - dt, 0)
+        if (!_playedSpawnSFX && _delaySpawnSFX <= 0) {
+            var audioEmitter = _rootEntity.GetAudioEmitterComponent()
+            audioEmitter.AddEvent(engine.GetAudio().PlayEventOnce(_spawnSFX))
+            _playedSpawnSFX = true
+        }
 
         if (_isAlive) {
             if (_attackingState) {

--- a/game/gameplay/enemies/melee.wren
+++ b/game/gameplay/enemies/melee.wren
@@ -27,6 +27,7 @@ class MeleeEnemy {
         _bonesStepsSFX = "event:/SFX/BonesSteps"
         _roar = "event:/SFX/Roar"
         _hitSFX = "event:/SFX/Hit"
+        _spawnSFX = "event:/SFX/EnemySpawn"
 
         var enemySize = 0.0165
         var modelPath = "assets/models/Skeleton.glb"
@@ -43,6 +44,9 @@ class MeleeEnemy {
         _rootEntity.AddNameComponent().name = "Enemy"
         _rootEntity.AddEnemyTag()
         _rootEntity.AddAudioEmitterComponent()
+        
+        _delaySpawnSFX = Random.RandomFloatRange(0, 1500)
+        _playedSpawnSFX = false
 
         var transform = _rootEntity.AddTransformComponent()
         transform.translation = spawnPosition
@@ -180,6 +184,12 @@ class MeleeEnemy {
         var animations = _meshEntity.GetAnimationControlComponent()
         var transparencyComponent = _meshEntity.GetTransparencyComponent()
 
+        _delaySpawnSFX = Math.Max(_delaySpawnSFX - dt, 0)
+        if (!_playedSpawnSFX && _delaySpawnSFX <= 0) {
+            var audioEmitter = _rootEntity.GetAudioEmitterComponent()
+            audioEmitter.AddEvent(engine.GetAudio().PlayEventOnce(_spawnSFX))
+            _playedSpawnSFX = true
+        }
 
         if (_isAlive) {
             if (_getUpState) {

--- a/game/gameplay/enemies/ranged.wren
+++ b/game/gameplay/enemies/ranged.wren
@@ -27,6 +27,7 @@ class RangedEnemy {
         _shootSFX = "event:/SFX/EyeLaserBlast" 
         _chargeSFX = "event:/SFX/EyeLaserCharge"
         _hitSFX = "event:/SFX/EyeHit"
+        _spawnSFX = "event:/SFX/EnemySpawn"
 
         var enemyModel = "assets/models/eye.glb"
         var enemySize = 3.25
@@ -38,6 +39,9 @@ class RangedEnemy {
         _rootEntity.AddNameComponent().name = "Enemy"
         _rootEntity.AddEnemyTag()
         _rootEntity.AddAudioEmitterComponent()
+        
+        _delaySpawnSFX = Random.RandomFloatRange(0, 1500)
+        _playedSpawnSFX = false
 
         var transform = _rootEntity.AddTransformComponent()
         transform.translation = spawnPosition
@@ -181,6 +185,13 @@ class RangedEnemy {
         if (false) {
             engine.DrawDebugLine(pos, Vec3.new(pos.x, _maxHeight, pos.z))
             engine.DrawDebugLine(pos, Vec3.new(pos.x, _minHeight, pos.z))
+        }
+
+        _delaySpawnSFX = Math.Max(_delaySpawnSFX - dt, 0)
+        if (!_playedSpawnSFX && _delaySpawnSFX <= 0) {
+            var audioEmitter = _rootEntity.GetAudioEmitterComponent()
+            audioEmitter.AddEvent(engine.GetAudio().PlayEventOnce(_spawnSFX))
+            _playedSpawnSFX = true
         }
 
         if (_isAlive) {

--- a/game/gameplay/station.wren
+++ b/game/gameplay/station.wren
@@ -29,6 +29,7 @@ class Station {
         _time = 0.0 // Time since the station was spawned
         _ambientStationSound = "event:/SFX/StationAmbient"
         _ambientSoundEventInstance = null
+        _activateSFX = "event:/SFX/StationActivate" 
         _powerUpType = PowerUpType.NONE
 
 
@@ -108,6 +109,12 @@ class Station {
             var audioEmitter = _rootEntity.GetAudioEmitterComponent()
             audioEmitter.AddEvent(_ambientSoundEventInstance)
         }
+    }
+
+    PlayActivateSound(engine, volume) {
+        var eventInstance = engine.GetAudio().PlayEventOnce(_activateSFX)
+        engine.GetAudio().SetEventVolume(eventInstance, volume)
+        _rootEntity.GetAudioEmitterComponent().AddEvent(eventInstance)
     }
 
     StopSound(engine){
@@ -283,6 +290,7 @@ class StationManager {
             
             _stationList[randomIndex].SetPowerUpType(randomPowerUp) // Set the power up type to quad damage
             _stationList[randomIndex].time = 0.0 // Reset the time for the station
+            _stationList[randomIndex].PlayActivateSound(engine, 2.5)
             _quadDamageTransparency.transparency = 0.0 // Reset the transparency to 0.0
             _dualGunTransparency.transparency = 0.0 // Reset the transparency to 0.0
 


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Added features to indicate low player health & sound to indicate enemy spawns
- Heartbeat sound effect below 30% hp
- Lowpass filter below 30% hp
- Constant red vignette below 30% hp
- Enemy spawn SFX
- Powerup station activate SFX

videos in the show-and-tell forum

### Issues

https://bubonic-brotherhood.codecks.io/card/1zx-add-spawn-sfx-for-enemies
https://bubonic-brotherhood.codecks.io/card/21a-add-low-health-heartbeat-muffled
https://bubonic-brotherhood.codecks.io/card/1zo-add-sfx-when-power-up-station-becomes-active
https://bubonic-brotherhood.codecks.io/card/218-add-constant-vigenette-low-health-25

### Test criteria

- [ ] Get latest from perforce
- [ ] Get low health
- [ ] listen to enemies spawning (very subtle, might be inaudible with certain audio settings)
