### PR TITLE
Pause on controller disconnect & possible Steam Input fixes

### DIFF
--- a/engine/application/private/input/steam/steam_action_manager.cpp
+++ b/engine/application/private/input/steam/steam_action_manager.cpp
@@ -41,10 +41,7 @@ void SteamActionManager::SetGameActions(const GameActions& gameActions)
     _currentControllerState.clear();
     _prevControllerState.clear();
 
-    if (_inputDeviceManager.IsGamepadAvailable())
-    {
-        CacheSteamInputHandles();
-    }
+    CacheSteamInputHandles();
 
     if (!_gameActions.empty())
     {
@@ -207,6 +204,11 @@ void SteamActionManager::UpdateSteamControllerInputState()
 
 void SteamActionManager::CacheSteamInputHandles()
 {
+    if (!_inputDeviceManager.IsGamepadAvailable())
+    {
+        return;
+    }
+
     _steamGameActionsCache.resize(_gameActions.size());
 
     for (uint32_t i = 0; i < _gameActions.size(); ++i)

--- a/engine/application/private/input/steam/steam_action_manager.cpp
+++ b/engine/application/private/input/steam/steam_action_manager.cpp
@@ -25,6 +25,7 @@ void SteamActionManager::Update()
     }
 
     UpdateSteamControllerInputState();
+    SteamInput()->ActivateActionSet(_steamInputDeviceManager.GetGamepadHandle(), _steamGameActionsCache[_activeActionSet].actionSetHandle);
 }
 
 void SteamActionManager::SetGameActions(const GameActions& gameActions)
@@ -58,14 +59,6 @@ void SteamActionManager::SetGameActions(const GameActions& gameActions)
     {
         SetActiveActionSet(_gameActions[0].name);
     }
-}
-
-void SteamActionManager::SetActiveActionSet(std::string_view actionSetName)
-{
-    ActionManager::SetActiveActionSet(actionSetName);
-
-    SteamInput()->ActivateActionSet(_steamInputDeviceManager.GetGamepadHandle(), _steamGameActionsCache[_activeActionSet].actionSetHandle);
-    SteamInput()->RunFrame(); // Make sure a set is immediately used
 }
 
 std::vector<GamepadOriginVisual> SteamActionManager::GetDigitalActionGamepadOriginVisual(std::string_view actionName) const

--- a/engine/application/private/input/steam/steam_action_manager.hpp
+++ b/engine/application/private/input/steam/steam_action_manager.hpp
@@ -12,7 +12,6 @@ public:
 
     void Update() final;
     void SetGameActions(const GameActions& gameActions) final;
-    void SetActiveActionSet(std::string_view actionSetName) final;
 
     // Returns information to be visually displayed for all gamepad bindings for the given digital action.
     NO_DISCARD std::vector<GamepadOriginVisual> GetDigitalActionGamepadOriginVisual(std::string_view actionName) const final;

--- a/engine/application/private/input/steam/steam_action_manager.hpp
+++ b/engine/application/private/input/steam/steam_action_manager.hpp
@@ -41,4 +41,5 @@ private:
     NO_DISCARD DigitalActionType CheckInput(std::string_view actionName, MAYBE_UNUSED GamepadButton button) const;
     NO_DISCARD glm::vec2 CheckInput(std::string_view actionName, MAYBE_UNUSED GamepadAnalog gamepadAnalog) const final;
     void UpdateSteamControllerInputState();
+    void CacheSteamInputHandles();
 };

--- a/engine/application/public/input/action_manager.hpp
+++ b/engine/application/public/input/action_manager.hpp
@@ -97,7 +97,7 @@ public:
     // Sets the actions in the game, the first set in the game actions is assumed to be the used set.
     virtual void SetGameActions(const GameActions& gameActions) { _gameActions = gameActions; }
     // Change the currently used action set in the game actions.
-    virtual void SetActiveActionSet(std::string_view actionSetName);
+    void SetActiveActionSet(std::string_view actionSetName);
     // Sets custom gamepad glyph paths to be taken into account
     void SetCustomInputGlyphs(const GamepadGlyphs& gamepadGlyphs) { _gamepadGlyphs = gamepadGlyphs; }
 

--- a/engine/bindings/private/input/input_bindings.cpp
+++ b/engine/bindings/private/input/input_bindings.cpp
@@ -48,6 +48,11 @@ bool IsInputEnabled(ApplicationModule& self)
     return self.GetMouseHidden();
 }
 
+bool IsGamepadConnected(ApplicationModule& self)
+{
+    return self.GetInputDeviceManager().IsGamepadAvailable();
+}
+
 bool GetRawKeyOnce(ApplicationModule& self, KeyboardCode code)
 {
     return self.GetInputDeviceManager().IsKeyPressed(code);
@@ -73,6 +78,8 @@ void BindInputAPI(wren::ForeignModule& module)
     wrenClass.funcExt<bindings::GetRawKeyHeld>("DebugGetHeldKey");
     wrenClass.funcExt<bindings::GetMousePosition>("GetMousePosition");
     wrenClass.funcExt<bindings::IsInputEnabled>("DebugIsInputEnabled");
+
+    wrenClass.funcExt<bindings::IsGamepadConnected>("IsGamepadConnected");
 
     auto& digitalActionResult = module.klass<DigitalActionResult>("DigitalActionResult");
     digitalActionResult.funcExt<bindings::GetDigitalActionIsPressed>("IsPressed");

--- a/game/game.wren
+++ b/game/game.wren
@@ -272,6 +272,8 @@ class Main {
         }
 
         retryButton.OnPress(retryHandler)
+
+        __gamepadConnectedPrevFrame = engine.GetInput().IsGamepadConnected()
     }
 
     static Shutdown(engine) {
@@ -307,6 +309,14 @@ class Main {
             return
         }
 
+        // Pause the game if the controller disconnects
+        var hasGamepadDisconnected = __gamepadConnectedPrevFrame && !engine.GetInput().IsGamepadConnected()
+        __gamepadConnectedPrevFrame = engine.GetInput().IsGamepadConnected()
+
+        if (!__pauseEnabled && hasGamepadDisconnected) {
+            __pauseHandler.call()
+        }
+
         __playerMovement.lookSensitivity = engine.GetGame().GetSettings().aimSensitivity * (2.5 - 0.2) + 0.2
 
         if (__enemyList.count != 0) {
@@ -324,7 +334,7 @@ class Main {
             engine.GetAudio().DisableLowPass()
         }
 
-        
+
 
         var cheats = __playerController.GetCheatsComponent()
         var deltaTime = engine.GetTime().GetDeltatime()


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Adds pausing the game when a controller disconnects.

Also possible Steam Input fixes? Whenever the controller was not there the first frame, and a controller is connected later,
Steam input didn't work, because caching Steam input handles only works when a controller is available. Also setting the active action set is now done in the update loop, as recommended by Steam.

### Issues

https://bubonic-brotherhood.codecks.io/milestones/run/72/card/221-pause-game-when-controller-disconnects
https://bubonic-brotherhood.codecks.io/milestones/run/72/card/222-steam-input-does-not-work-when-diconnected (maybe related)

### Test criteria

- The game is paused when the controller disconnects during gameplay
