### PR TITLE
Fix/controls screen gamepad

### DIFF
--- a/engine/application/private/input/steam/steam_input_device_manager.cpp
+++ b/engine/application/private/input/steam/steam_input_device_manager.cpp
@@ -69,7 +69,6 @@ void SteamInputDeviceManager::UpdateControllerConnectivity()
         }
 
         _inputHandle = 0;
-        bblog::warn("No controller found!");
         return;
     }
 

--- a/engine/game/private/game_module.cpp
+++ b/engine/game/private/game_module.cpp
@@ -126,6 +126,7 @@ ModuleTickOrder GameModule::Init(Engine& engine)
 
     auto openControlsMenu = [this, &engine]()
     {
+        this->_controlsMenu.lock()->UpdateBindings();
         this->PushUIMenu(this->_controlsMenu);
         this->PushPreviousFocusedElement(_mainMenu.lock()->controlsButton);
         engine.GetModule<UIModule>().uiInputContext.focusedUIElement = this->_controlsMenu.lock()->backButton;

--- a/engine/game/private/ui/controls_menu.cpp
+++ b/engine/game/private/ui/controls_menu.cpp
@@ -137,6 +137,7 @@ ControlsMenu::ActionControls ControlsMenu::AddActionVisualization(const std::str
     constexpr float originHorizontalMargin = 225.0f;
     constexpr float actionOriginBindingTextMarginMultiplier = 12.0f;
     constexpr float canvasScaleY = actionTextSize + 10.0f;
+    constexpr uint32_t maxBindingsShown = 3;
 
     ActionControls action {};
     action.canvas = parent.AddChild<Canvas>(glm::vec2 { _canvasResolution.x, canvasScaleY });
@@ -151,8 +152,10 @@ ControlsMenu::ActionControls ControlsMenu::AddActionVisualization(const std::str
     const std::vector<BindingOriginVisual> blindingOrigins = isAnalogInput ? _actionManager.GetAnalogActionBindingOriginVisual(actionName) : _actionManager.GetDigitalActionBindingOriginVisual(actionName);
     float horizontalOffset = _canvasResolution.x / 6.0f;
 
-    for (const BindingOriginVisual& origin : blindingOrigins)
+    const uint32_t numBindingsToShow = glm::min(maxBindingsShown, static_cast<uint32_t>(blindingOrigins.size()));
+    for (uint32_t i = 0; i < numBindingsToShow; ++i)
     {
+        const BindingOriginVisual& origin = blindingOrigins[i];
         ActionControls::Binding& binding = action.bindings.emplace_back();
 
         // Create binding text

--- a/engine/game/private/ui/settings_menu.cpp
+++ b/engine/game/private/ui/settings_menu.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<SettingsMenu> SettingsMenu::Create(
             node->SetLocation(elemPos);
             elemPos += increment;
 
-            auto text = node->AddChild<UITextElement>(font, "Aim Assist", glm::vec2(), textSize);
+            auto text = node->AddChild<UITextElement>(font, "Auto-Aim Assist", glm::vec2(), textSize);
             text->anchorPoint = UIElement::AnchorPoint::eTopLeft;
 
             auto toggle = node->AddChild<UIToggle>(toggleStyle, toggleOffset + glm::vec2(sliderSize.x - toggleSize.x, 0), toggleSize);


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Fixes an issue where the bindings were not visible for controllers in the controls screen.
Now the visuals are updated every time you open the menu to support changing bindings via the steam overlay.

### Test criteria

- [ ] The controller bindings are visible in the controls screen when playing with a controller connected
