### PR TITLE
[FIX] Using Steam Input without internet

### DIFF
--- a/engine/game/private/game_module.cpp
+++ b/engine/game/private/game_module.cpp
@@ -180,6 +180,7 @@ ModuleTickOrder GameModule::Init(Engine& engine)
 
     auto openControlsPause = [this, &engine]()
     {
+        this->_controlsMenu.lock()->UpdateBindings();
         this->PushUIMenu(this->_controlsMenu);
         this->PushPreviousFocusedElement(_pauseMenu.lock()->controlsButton);
         engine.GetModule<UIModule>().uiInputContext.focusedUIElement = this->_controlsMenu.lock()->backButton;


### PR DESCRIPTION
### Reviewer steps

- [ ] I can build the project locally
- [ ] I have tested and approved the features from this pull request
- [ ] I have checked and approved the test criteria
- [ ] I have reviewed the files in the pull request
- [ ] I have looked at and updated the related issues in Codecks

### Description

Fixed an issue where running the game without internet and Steam Input doesn't work.
Now the Steam User doesn't have to be logged in to use steam input (happens when no internet is available).
When the user is logged off it's account entirely, but has internet. The base Steam API will not work at all, so in that case we can not make Steam Input work. But now when testing on Steam Deck and running without internet, Steam Input should work.

Also fixed an issue where the glyphs wouldn't show up using the next steps ->
1. Launch the game without controller
2. Connect the controller
3. Press play and load the game
4. Go to the pause menu and open the controls screen

### Issues

[codecks card](https://bubonic-brotherhood.codecks.io/milestones/run/73/card/222-steam-input-does-not-work-when-diconnected)

### Test criteria

- [ ] When running the game without internet, with Steam open in the background, Steam Input should be used and work
- [ ] When following the steps above, the glyphs show up in the pause menu controls screen
